### PR TITLE
Add back button to shutdown details page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import LineGraph from './components/LineGraph';
 import ShutdownContainer from './components/Shutdowns/ShutdownContainer';
 import { useStore } from './store';
 import { colorToStyle } from './styles';
+import { useState } from 'react';
 
 import Navbar from './components/Navbar';
 import ShutdownDetails from './components/Shutdowns/ShutdownDetails';
@@ -52,6 +53,8 @@ const queryClient = new QueryClient({
 function App() {
   const { selectedLine, details } = useStore();
 
+  const [showDetails, setShowDetails] = useState(false);
+
   return (
     <QueryClientProvider client={queryClient}>
       <div
@@ -64,12 +67,18 @@ function App() {
       <div className="dark:bg-slate-800 bg-slate-100 ">
         <Navbar />
         <div className="md:px-12 p-6 ">
-          {details ? (
-            <ShutdownDetails details={details} />
+          {showDetails && details ? (
+            <ShutdownDetails
+              line={details.line}
+              shutdown={details.shutdown}
+              handleBack={() => {
+                setShowDetails(false);
+              }}
+            />
           ) : (
             <>
               <LineGraph />
-              <ShutdownContainer />
+              <ShutdownContainer handleClick={() => setShowDetails(true)} />
             </>
           )}
         </div>

--- a/src/components/Shutdowns/ShutdownCard.tsx
+++ b/src/components/Shutdowns/ShutdownCard.tsx
@@ -6,9 +6,10 @@ import ShutdownTitle from './ShutdownTitle';
 interface ShutdownCardProps {
   shutdown: Shutdown;
   line: Lines;
+  handleClick: () => void;
 }
 
-const ShutdownCard = ({ shutdown, line }: ShutdownCardProps) => {
+const ShutdownCard = ({ shutdown, line, handleClick }: ShutdownCardProps) => {
   const key = `${shutdown.start_station.stop_name}-${shutdown.end_station.stop_name}-${shutdown.start_date}-${shutdown.stop_date}`;
 
   return (
@@ -18,7 +19,7 @@ const ShutdownCard = ({ shutdown, line }: ShutdownCardProps) => {
         name={key}
         className={`rounded-lg bg-white dark:bg-slate-700 p-4 shadow border-r-8 ${colorToStyle[line].border}`}
       >
-        <ShutdownTitle shutdown={shutdown} line={line} />
+        <ShutdownTitle shutdown={shutdown} line={line} handleClick={handleClick}/>
       </div>
     </>
   );

--- a/src/components/Shutdowns/ShutdownContainer.tsx
+++ b/src/components/Shutdowns/ShutdownContainer.tsx
@@ -4,7 +4,7 @@ import { Lines, useStore } from '../../store';
 import { shutdowns } from '../../constants/shutdowns';
 import ShutdownCard from './ShutdownCard';
 
-const ShutdownCards = () => {
+const ShutdownCards = ({ handleClick }: { handleClick: () => void }) => {
   const { selectedLine } = useStore();
 
   const mappedShutdowns = useMemo(
@@ -19,6 +19,7 @@ const ShutdownCards = () => {
                 key={`${line}-${sd.start_date}-${sd.stop_date}-${index}`}
                 line={line as Lines}
                 shutdown={sd}
+                handleClick={handleClick}
               />
             ))
         ),

--- a/src/components/Shutdowns/ShutdownDetails.tsx
+++ b/src/components/Shutdowns/ShutdownDetails.tsx
@@ -3,19 +3,48 @@ import { abbreviateStationName } from '../../constants/stations';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { Lines } from '../../store';
 import { useTripExplorerQueries } from '../../api/traveltimes';
-import { Shutdown } from '../../types';
+import { Shutdown, Station } from '../../types';
 import { stopIdsForStations } from '../../utils/stations';
 import { cardStyles } from '../../constants/styles';
 import ChartContainer from './ChartContainer';
 import ShutdownMap from './ShutdownMap';
 import StatusBadge from './StatusBadge';
+import { ArrowLeftIcon } from '@heroicons/react/24/solid';
 
 const ShutdownDetails = ({
-  details: { line, shutdown },
+  line,
+  shutdown,
+  handleBack,
 }: {
-  details: { line: Lines; shutdown: Shutdown };
+  line: Lines;
+  shutdown: Shutdown;
+  handleBack: () => void;
 }) => {
+  const formatDate = (date) => dayjs(date).format('MM/DD/YY');
   const isMobile = useBreakpoint('sm');
+
+  const displayStationName = (station: Station) =>
+    isMobile ? station.stop_name : abbreviateStationName(station.stop_name);
+
+  // Shutdown title card component
+  const ShutdownTitleCard = () => {
+    return (
+      <div className={`flex flex-row pb-3 ${cardStyles}`}>
+        <div className="items-center">
+          <div className="text-base md:text-2xl items-center flex flex-row dark:text-white ">
+            <h3>{`${displayStationName(shutdown.start_station)} - ${displayStationName(shutdown.end_station)}`}</h3>
+            <StatusBadge start_date={shutdown.start_date} stop_date={shutdown.stop_date} />
+          </div>
+          <div className="mt-1 text-gray-500 dark:text-slate-400">
+            <p>
+              {formatDate(shutdown.start_date)} - {formatDate(shutdown.stop_date)}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const { fromStopIds, toStopIds } = stopIdsForStations(
     shutdown.start_station,
     shutdown.end_station
@@ -46,51 +75,37 @@ const ShutdownDetails = ({
     headways: hh,
   } = useTripExplorerQueries(beforeShutdownQueryOptions, true);
 
-  const formatDate = (date) => dayjs(date).format('MM/DD/YY');
-  const displayStationName = (station) =>
-    isMobile ? station.stop_name : abbreviateStationName(station.stop_name);
+  // Shutdown Data Cards
+  const DataCards = () => {
+    return (
+      <div className="flex flex-auto flex-col gap-4">
+        <ChartContainer before={tt} after={traveltimes} shutdown={shutdown} title="Travel times" />
+        <ChartContainer before={dd} after={dwells} shutdown={shutdown} title="Dwells" />
+        <ChartContainer before={hh} after={headways} shutdown={shutdown} title="Headways" />
+      </div>
+    );
+  };
+
+  // Back button to exit the details page
+  const PageBackButton = () => {
+    return (
+      <div className="flex flex-row items-center cursor-pointer" onClick={handleBack}>
+        <ArrowLeftIcon className="h-4 px-1" />
+        <h3>Back</h3>
+      </div>
+    );
+  };
 
   return (
     <div className="mb-6">
-      <div className={`flex flex-col md:flex-row gap-4`}>
-        <div className="flex flex-auto flex-col">
-          <div className={`flex flex-row pb-3 ${cardStyles}`}>
-            <div className="items-center">
-              <div className="text-base md:text-2xl items-center flex flex-row dark:text-white ">
-                {displayStationName(shutdown.start_station)}
-                {' - '}
-                {displayStationName(shutdown.end_station)}
-
-                <StatusBadge start_date={shutdown.start_date} stop_date={shutdown.stop_date} />
-              </div>
-              <div className="mt-1 text-gray-500 dark:text-slate-400">
-                {formatDate(shutdown.start_date)} - {formatDate(shutdown.stop_date)}
-              </div>
-            </div>
+      <div className="flex flex-col gap-4">
+        <PageBackButton />
+        <ShutdownTitleCard />
+        <div className="flex flex-col md:flex-row gap-4">
+          <DataCards />
+          <div className="flex justify-center rounded-lg bg-white dark:dark:bg-slate-700 dark:text-white pt-4 md:p-4 shadow">
+            <ShutdownMap shutdown={shutdown} line={line} />
           </div>
-
-          <div className="mt-4">
-            <ChartContainer
-              before={tt}
-              after={traveltimes}
-              shutdown={shutdown}
-              title="Travel times"
-            />
-          </div>
-
-          <div className="mt-4">
-            <ChartContainer before={dd} after={dwells} shutdown={shutdown} title="Dwells" />
-          </div>
-
-          <div className="mt-4">
-            <ChartContainer before={hh} after={headways} shutdown={shutdown} title="Headways" />
-          </div>
-        </div>
-
-        <div
-          className={`flex justify-center rounded-lg bg-white dark:dark:bg-slate-700 dark:text-white pt-4 md:p-4 shadow`}
-        >
-          <ShutdownMap shutdown={shutdown} line={line} />
         </div>
       </div>
     </div>

--- a/src/components/Shutdowns/ShutdownTitle.tsx
+++ b/src/components/Shutdowns/ShutdownTitle.tsx
@@ -6,7 +6,15 @@ import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { Lines, useStore } from '../../store';
 import StatusBadge from './StatusBadge';
 
-const ShutdownTitle = ({ shutdown, line }: { shutdown: Shutdown; line: Lines }) => {
+const ShutdownTitle = ({
+  shutdown,
+  line,
+  handleClick,
+}: {
+  shutdown: Shutdown;
+  line: Lines;
+  handleClick: () => void;
+}) => {
   const { setDetails } = useStore();
 
   const isMobile = useBreakpoint('sm');
@@ -32,7 +40,10 @@ const ShutdownTitle = ({ shutdown, line }: { shutdown: Shutdown; line: Lines }) 
       </div>
       <ChartBarIcon
         className="text-white bg-tm-grey rounded shadow h-7 w-7 p-1 pointer cursor-pointer hover:scale-110"
-        onClick={() => setDetails(shutdown, line)}
+        onClick={() => {
+          setDetails(shutdown, line);
+          handleClick();
+        }}
       />
     </div>
   );


### PR DESCRIPTION
## Motivation

Addresses #14 

## Changes

- Adds a back button on the shutdown details page
    - Moves some state in the app to the top level to manage showing/hiding shutdown details
## Testing Instructions

1. Click on a shutdown from the list
2. Click the back button
