### PR TITLE
feat: add button toggle for northbound & southbound

### DIFF
--- a/src/components/Shutdowns/ShutdownDetails.tsx
+++ b/src/components/Shutdowns/ShutdownDetails.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
-import { ArrowLeftIcon } from '@heroicons/react/24/solid';
+import { ArrowDownIcon, ArrowLeftIcon, ArrowUpIcon } from '@heroicons/react/24/solid';
+import { useState } from 'react';
 import { abbreviateStationName } from '../../constants/stations';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { Lines } from '../../store';
@@ -7,6 +8,7 @@ import { useTripExplorerQueries } from '../../api/traveltimes';
 import { Shutdown, Station } from '../../types';
 import { getStationByName, stopIdsForStations } from '../../utils/stations';
 import { cardStyles } from '../../constants/styles';
+import { colorToStyle } from '../../styles';
 import ChartContainer from './ChartContainer';
 import ShutdownMap from './ShutdownMap';
 import StatusBadge from './StatusBadge';
@@ -26,6 +28,9 @@ const ShutdownDetails = ({
   start_station: string;
   end_station: string;
 }) => {
+  const [isReversed, setIsReversed] = useState(false);
+  const direction = isReversed ? 'Northbound' : 'Southbound';
+  const Icon = isReversed ? ArrowUpIcon : ArrowDownIcon;
   const isMobile = useBreakpoint('sm');
   const displayStationName = (station: Station) =>
     isMobile ? station.stop_name : abbreviateStationName(station.stop_name);
@@ -40,14 +45,18 @@ const ShutdownDetails = ({
     end_station: endStation,
   };
 
+  const handleToggleDirection = () => {
+    setIsReversed((prev) => !prev);
+  };
+
   // Shutdown title card component
   const ShutdownTitleCard = () => {
     const formatDate = (date: string) => dayjs(date).format('MM/DD/YY');
 
     return (
-      <div className={`flex flex-row pb-3 ${cardStyles}`}>
-        <div className="items-center">
-          <div className="text-base md:text-2xl items-center flex flex-row dark:text-white ">
+      <div className={`flex flex-row justify-between pb-3 ${cardStyles}`}>
+        <div className="flex flex-col items-start">
+          <div className="text-base md:text-2xl items-center flex flex-row dark:text-white">
             <h3>{`${shutdown.start_station ? displayStationName(shutdown.start_station) : start_station} - ${shutdown.end_station ? displayStationName(shutdown.end_station) : end_station}`}</h3>
             <StatusBadge start_date={shutdown.start_date} stop_date={shutdown.stop_date} />
           </div>
@@ -57,13 +66,25 @@ const ShutdownDetails = ({
             </p>
           </div>
         </div>
+        <div className="flex justify-center items-start h-full">
+          <button
+            title={isReversed ? 'Northbound' : 'Southbound'}
+            onClick={handleToggleDirection}
+            className={`p-2 ${colorToStyle[line].bg} ${colorToStyle[line].hover} rounded-full sm:rounded-lg flex items-center justify-center text-white focus:outline-none h-1/2`}
+          >
+            <span className="flex items-center">
+              <Icon className="h-5 w-5 text-white" />
+              {isMobile && <p>{direction}</p>}
+            </span>
+          </button>
+        </div>
       </div>
     );
   };
 
   const { fromStopIds, toStopIds } = stopIdsForStations(
-    shutdown.start_station,
-    shutdown.end_station
+    isReversed ? shutdown.end_station : shutdown.start_station,
+    isReversed ? shutdown.start_station : shutdown.end_station
   );
 
   const queryOptions = {


### PR DESCRIPTION
## Motivation
We need a toggle that reverses `start_station` and `end_station` params so that we can see shutdown metrics for both Northbound and Southbound segments.

## Changes
https://github.com/transitmatters/shutdown-tracker/assets/47030097/2280e417-3eb4-4f27-8741-530a65d14a34

## Testing Instructions
1. Pull down this branch 
2. Go to an ongoing shutdown
3. Toggle the button to switch between Northbound and Southbound data
