### PR TITLE
Allow filtering shutdowns by all, future, past

### DIFF
--- a/src/components/LineButtons.tsx
+++ b/src/components/LineButtons.tsx
@@ -25,7 +25,7 @@ export const LineButtons = () => {
               'transition ease-in-out'
             )}
           >
-            {line}
+            {line === 'all' ? 'All lines' : `${line} line`}
           </Listbox.Button>
           <Transition
             enter="transition duration-100 ease-out"
@@ -51,7 +51,7 @@ export const LineButtons = () => {
                       'transition ease-in-out'
                     )}
                   >
-                    {color === 'all' ? 'All' : ` ${capitalize(color)} line`}
+                    {color === 'all' ? 'All lines' : ` ${capitalize(color)} line`}
                   </Listbox.Option>
                 </Link>
               ))}

--- a/src/components/LineButtons.tsx
+++ b/src/components/LineButtons.tsx
@@ -14,7 +14,7 @@ export const LineButtons = () => {
 
   if (!isMobile) {
     return (
-      <div className="pt-3 dark:text-white text-black font-bold text-xs md:text-base border-1">
+      <div className="pt-3 dark:text-white text-black font-bold text-xs md:text-base border-1 w-full">
         <Listbox value={line} onChange={setLine}>
           <Listbox.Button
             className={classNames(

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -21,14 +21,10 @@ dayjs.extend(utc);
 
 interface LineGraphProps {
   line: Lines | 'all';
-  upcoming?: boolean;
 }
 
-export const LineGraph: React.FunctionComponent<LineGraphProps> = ({
-  line: selectedLine,
-  upcoming = false,
-}) => {
-  const { darkMode } = useStore();
+export const LineGraph: React.FunctionComponent<LineGraphProps> = ({ line: selectedLine }) => {
+  const { darkMode, range } = useStore();
   const isMobile = !useBreakpoint('sm');
 
   const ref = useRef();
@@ -139,10 +135,14 @@ export const LineGraph: React.FunctionComponent<LineGraphProps> = ({
             scales: {
               x: {
                 type: 'time',
-                min: upcoming
-                  ? dayjs(new Date()).toISOString()
-                  : dayjs(new Date(2023, 11, 1)).toISOString(),
-                max: dayjs(new Date(2024, 11, 31)).toISOString(),
+                min:
+                  range === 'future'
+                    ? dayjs(new Date()).toISOString()
+                    : dayjs(new Date(2023, 11, 1)).toISOString(),
+                max:
+                  range === 'past'
+                    ? dayjs(new Date()).toISOString()
+                    : dayjs(new Date(2024, 11, 25)).toISOString(),
                 time: { unit: 'month' },
                 adapters: {
                   date: {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,7 +9,7 @@ const Navbar = ({ children }: { children?: ReactNode }) => {
         <Title />
         <ThemeSwitcher />
       </div>
-      {children}
+      <div className="flex flex-col md:flex-row md:justify-between w-full">{children}</div>
     </div>
   );
 };

--- a/src/components/RangeButtons.tsx
+++ b/src/components/RangeButtons.tsx
@@ -11,9 +11,9 @@ import { useStore } from '../store';
 import { capitalize, colorToStyle } from '../styles';
 
 const RANGE_ICONS = {
-  all: <PlayIcon className="h-5 w-5 text-white" />,
-  past: <BackwardIcon className="h-5 w-5 text-white" />,
-  future: <ForwardIcon className="h-5 w-5 text-white" />,
+  all: <PlayIcon className="h-4 md:h-5 w-4 md:w-5 text-white" />,
+  past: <BackwardIcon className="h-4 md:h-5 w-4 md:w-5 text-white" />,
+  future: <ForwardIcon className="h-4 md:h-5 w-4 md:w-5 text-white" />,
 };
 
 export const RangeButtons = () => {

--- a/src/components/RangeButtons.tsx
+++ b/src/components/RangeButtons.tsx
@@ -1,0 +1,71 @@
+import classNames from 'classnames';
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+  Transition,
+} from '@headlessui/react';
+import { BackwardIcon, ForwardIcon, PlayIcon } from '@heroicons/react/24/solid';
+import { useStore } from '../store';
+import { capitalize, colorToStyle } from '../styles';
+
+const RANGE_ICONS = {
+  all: <PlayIcon className="h-5 w-5 text-white" />,
+  past: <BackwardIcon className="h-5 w-5 text-white" />,
+  future: <ForwardIcon className="h-5 w-5 text-white" />,
+};
+
+export const RangeButtons = () => {
+  const { range, setRange } = useStore();
+
+  return (
+    <div className="pt-3 dark:text-white text-black font-bold text-xs md:text-base border-1 md:w-auto w-full">
+      <Listbox value={range} onChange={setRange}>
+        <ListboxButton
+          className={classNames(
+            colorToStyle['all'].bg,
+            `uppercase px-3 py-1 hover:ring-2 w-full`,
+            `rounded text-white`,
+            colorToStyle['all'].hover,
+            'transition ease-in-out cursor-pointer'
+          )}
+        >
+          {range} shutdowns
+        </ListboxButton>
+        <Transition
+          enter="transition duration-100 ease-out"
+          enterFrom="transform scale-95 opacity-0"
+          enterTo="transform scale-100 opacity-100"
+          leave="transition duration-75 ease-out"
+          leaveFrom="transform scale-100 opacity-100"
+          leaveTo="transform scale-95 opacity-0"
+        >
+          <ListboxOptions className={'md:absolute md:z-10'}>
+            {(['all', 'past', 'future'] as ('all' | 'past' | 'future')[]).map((selectedRange) => (
+              <ListboxOption
+                key={`button-range-${selectedRange}`}
+                value={selectedRange}
+                className={classNames(
+                  'border-1',
+                  colorToStyle['all'].bg,
+                  `md:uppercase px-3 py-1 m-2 hover:ring-2`,
+                  `rounded text-white`,
+                  colorToStyle['all'].hover,
+                  'hover:scale-105',
+                  'transition ease-in-out cursor-pointer'
+                )}
+                onClick={() => setRange(selectedRange)}
+              >
+                <span className="flex flex-row gap-1">
+                  {RANGE_ICONS[selectedRange]}
+                  {`${capitalize(selectedRange)} shutdowns`}
+                </span>
+              </ListboxOption>
+            ))}
+          </ListboxOptions>
+        </Transition>
+      </Listbox>
+    </div>
+  );
+};

--- a/src/components/Shutdowns/ShutdownMap.tsx
+++ b/src/components/Shutdowns/ShutdownMap.tsx
@@ -21,7 +21,7 @@ const ShutdownMap = ({ shutdown, line }: { shutdown: Shutdown; line: Lines }) =>
 
   const diagram = useMemo(() => {
     return createStraightLineDiagram(stops, {
-      pxPerStation: (isMobile ? 375 : 75) / stops.length,
+      pxPerStation: (isMobile ? 350 : 75) / stops.length,
     });
   }, [isMobile, stops]);
 

--- a/src/components/Shutdowns/ShutdownTitle.tsx
+++ b/src/components/Shutdowns/ShutdownTitle.tsx
@@ -12,16 +12,14 @@ const ShutdownTitle = ({ shutdown, line }: { shutdown: Shutdown; line: Lines }) 
   const navigate = useNavigate({ from: '/$line' });
 
   return (
-    <div className="flex flex-row justify-between items-start border-b border-gray-200 pb-3">
+    <div className="flex flex-row justify-between items-start">
       <div className="items-center">
         <div className="text-sm md:text-lg items-center flex flex-row dark:text-white">
-          {!isMobile
-            ? abbreviateStationName(shutdown.start_station?.stop_name)
-            : shutdown.start_station?.stop_name}
-          {' - '}
-          {!isMobile
-            ? abbreviateStationName(shutdown.end_station?.stop_name)
-            : shutdown.end_station?.stop_name}
+          <div>
+            {abbreviateStationName(shutdown.start_station?.stop_name, isMobile)}
+            {' - '}
+            {abbreviateStationName(shutdown.end_station?.stop_name, isMobile)}
+          </div>
 
           <StatusBadge start_date={shutdown.start_date} stop_date={shutdown.stop_date} />
         </div>
@@ -31,7 +29,8 @@ const ShutdownTitle = ({ shutdown, line }: { shutdown: Shutdown; line: Lines }) 
         </div>
       </div>
       <ChartBarIcon
-        className="text-white bg-tm-grey rounded shadow h-7 w-7 p-1 pointer cursor-pointer hover:scale-110"
+        className="text-white bg-tm-lightGrey dark:bg-gray-500 rounded shadow h-7 w-7 p-1 pointer cursor-pointer hover:scale-110"
+        title={'See Analysis'}
         onClick={() => {
           navigate({
             to: '/$line',

--- a/src/components/Shutdowns/StatusBadge.tsx
+++ b/src/components/Shutdowns/StatusBadge.tsx
@@ -13,7 +13,7 @@ const StatusBadge = ({ start_date, stop_date }: StatusBadgeProps) => {
 
   const status = start.isAfter(today)
     ? 'Not Started'
-    : end.isBefore(today)
+    : end.isBefore(today, 'day')
       ? 'Finished'
       : 'In Progress';
 

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -279,6 +279,13 @@
       "alert": "https://www.mbta.com/news/2024-03-15/april-service-changes-mbta-continues-work-improve-reliability-across-the-system"
     },
     {
+      "start_station": "Oak Grove",
+      "end_station": "North Station",
+      "start_date": "2024-05-17",
+      "stop_date": "2024-05-19",
+      "alert": "https://www.mbta.com/alerts"
+    },
+    {
       "start_station": "Wellington",
       "end_station": "Back Bay",
       "start_date": "2024-05-28",

--- a/src/constants/stations.ts
+++ b/src/constants/stations.ts
@@ -6,24 +6,29 @@ export const rtStations: { [key in Lines]: LineMap } = stations_json;
 
 export const stations = { ...rtStations };
 
-export const abbreviateStationName = (stationName: string | undefined) => {
+export const abbreviateStationName = (stationName: string | undefined, isMobile?: boolean) => {
   if (stationName?.startsWith('JFK')) {
-    return 'JFK';
+    return 'JFK/UMass';
   }
-  return stationName
-    ?.replace('Downtown Crossing', 'Dwntn Crossing')
-    .replace('Boston University', 'BU')
-    .replace('Hynes Convention Center', 'Hynes')
-    .replace('Government Center', "Gov't Center")
-    .replace('Northeastern University', 'Northeastern')
-    .replace('Museum of Fine Arts', 'MFA')
-    .replace('Massachusetts Avenue', 'Mass Ave')
-    .replace('North Quincy', 'N. Quincy')
-    .replace('Longwood Medical Area', 'Longwood Med')
-    .replace('Street', 'St.')
-    .replace('Avenue', 'Ave')
-    .replace('Square', 'Sq.')
-    .replace('Road', 'Rd')
-    .replace('Circle', 'Cir')
-    .replace('Medford/Tufts', 'Medford');
+
+  if (!isMobile) {
+    return stationName
+      ?.replace('Downtown Crossing', 'Dwntn Crossing')
+      .replace('Boston University', 'BU')
+      .replace('Hynes Convention Center', 'Hynes')
+      .replace('Government Center', "Gov't Center")
+      .replace('Northeastern University', 'Northeastern')
+      .replace('Museum of Fine Arts', 'MFA')
+      .replace('Massachusetts Avenue', 'Mass Ave')
+      .replace('North Quincy', 'N. Quincy')
+      .replace('Longwood Medical Area', 'Longwood Med')
+      .replace('Street', 'St.')
+      .replace('Avenue', 'Ave')
+      .replace('Square', 'Sq.')
+      .replace('Road', 'Rd')
+      .replace('Circle', 'Cir')
+      .replace('Medford/Tufts', 'Medford');
+  }
+
+  return stationName;
 };

--- a/src/routes/$line/index.tsx
+++ b/src/routes/$line/index.tsx
@@ -9,6 +9,7 @@ import { ShutdownCards } from '../../components/Shutdowns/ShutdownContainer';
 import { Lines } from '../../store';
 import { LineButtons } from '../../components/LineButtons';
 import Footer from '../../components/Footer';
+import { RangeButtons } from '../../components/RangeButtons';
 
 interface SearchParams {
   start_station?: string;
@@ -43,6 +44,7 @@ function Line() {
       <div className="dark:bg-slate-800 bg-slate-100 ">
         <Navbar>
           <LineButtons />
+          <RangeButtons />
         </Navbar>
         <div className="md:px-12 p-6">
           {search.start_date &&

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -147,7 +147,7 @@ const Home = () => {
             </div>
           </div>
           <div className="">
-            <LineGraph line={'all'} upcoming />
+            <LineGraph line={'all'} />
           </div>
 
           <div className="flex justify-center mb-4">

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,11 +18,15 @@ export interface Store {
   setDarkMode: (mode: boolean) => void;
   details?: { shutdown: Shutdown; line: Lines };
   setDetails: (details: Shutdown, line: Lines) => void;
+  range: 'all' | 'past' | 'future';
+  setRange: (range: 'all' | 'past' | 'future') => void;
 }
 
 export const useStore = create<Store>((set) => ({
-  selectedLine: 'red',
+  selectedLine: 'all',
   setLine: (line: Store['selectedLine']) => set({ selectedLine: line }),
   setDarkMode: (mode: boolean) => set({ darkMode: mode }),
   setDetails: (shutdown: Shutdown, line: Lines) => set({ details: { shutdown, line } }),
+  range: 'all',
+  setRange: (range: 'all' | 'past' | 'future') => set({ range }),
 }));


### PR DESCRIPTION
## Motivation

Fixes #48

Allow filtering shutdowns by all, past and future

## Changes

<img width="1246" alt="Screenshot 2024-05-19 at 3 37 43 PM" src="https://github.com/transitmatters/shutdown-tracker/assets/9310513/431eb621-1fc9-486d-97a1-5a75910f96b8">
<img width="1246" alt="Screenshot 2024-05-19 at 3 38 01 PM" src="https://github.com/transitmatters/shutdown-tracker/assets/9310513/7c8a8c29-cb1c-436c-8773-1332751c5bd4">

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
