### PR TITLE
Updating shutdowns for June 2024

### DIFF
--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -194,6 +194,34 @@
     },
     {
       "start_station": "Alewife",
+      "end_station": "Harvard",
+      "start_date": "2024-06-01",
+      "stop_date": "2024-06-02",
+      "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
+      "start_station": "Broadway",
+      "end_station": "Braintree",
+      "start_date": "2024-06-08",
+      "stop_date": "2024-06-09",
+      "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
+      "start_station": "Broadway",
+      "end_station": "Braintree",
+      "start_date": "2024-06-15",
+      "stop_date": "2024-06-16",
+      "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
+      "start_station": "Alewife",
+      "end_station": "Harvard",
+      "start_date": "2024-06-29",
+      "stop_date": "2024-06-30",
+      "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
+      "start_station": "Alewife",
       "end_station": "Kendall/MIT",
       "start_date": "2024-07-08",
       "stop_date": "2024-07-23",
@@ -290,14 +318,21 @@
       "end_station": "Back Bay",
       "start_date": "2024-05-28",
       "stop_date": "2024-06-06",
-      "alert": "https://www.mbta.com/news/2024-04-22/may-service-changes-mbta-continues-work-improve-reliability-across-the-system"
+      "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
+      "start_station": "Oak Grove",
+      "end_station": "North Station",
+      "start_date": "2024-06-07",
+      "stop_date": "2024-06-09",
+      "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
     },
     {
       "start_station": "Wellington",
       "end_station": "North Station",
-      "start_date": "2024-06-20",
-      "stop_date": "2024-06-27",
-      "alert": "https://www.mbta.com/alerts"
+      "start_date": "2024-06-22",
+      "stop_date": "2024-06-30",
+      "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
     },
     {
       "start_station": "Oak Grove",


### PR DESCRIPTION
## Motivation

https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the

## Changes

Update for June 2024 shutdowns

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
