### PR TITLE
Col/rl july update

### DIFF
--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -220,6 +220,27 @@
       "alert": "https://www.mbta.com/news/2024-05-20/june-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
     },
     {
+      "start_station": "Kendall/MIT",
+      "end_station": "Park Street",
+      "start_date": "2024-07-13",
+      "stop_date": "2024-07-14",
+      "alert": "https://www.mbta.com/news/2024-06-18/july-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "Park Street",
+      "start_date": "2024-07-20",
+      "stop_date": "2024-07-21",
+      "alert": "https://www.mbta.com/news/2024-06-18/july-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "Park Street",
+      "start_date": "2024-07-27",
+      "stop_date": "2024-07-28",
+      "alert": "https://www.mbta.com/news/2024-06-18/july-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
+    },
+    {
       "start_station": "Alewife",
       "end_station": "Kendall/MIT",
       "start_date": "2024-07-13",

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -77,7 +77,6 @@
       "stop_date": "2024-01-28",
       "alert": "https://www.mbta.com/alerts"
     },
-
     {
       "start_station": "Copley",
       "end_station": "Cleveland Circle",
@@ -223,9 +222,9 @@
     {
       "start_station": "Alewife",
       "end_station": "Kendall/MIT",
-      "start_date": "2024-07-08",
-      "stop_date": "2024-07-23",
-      "alert": "https://www.mbta.com/alerts"
+      "start_date": "2024-07-13",
+      "stop_date": "2024-07-28",
+      "alert": "https://www.mbta.com/news/2024-06-18/july-service-changes-mbta-continues-repair-work-improve-reliability-across-the"
     },
     {
       "start_station": "JFK/UMass (Braintree)",


### PR DESCRIPTION
## Motivation

Updates the RL July shutdown to match dates provided in the MBTA July service changes notification. As the shutdown's endpoint changes between Kendall/MIT and Park St, the shutdown is broken into 4 separate pieces (1 long shutdown for Alewife-Kendall/MIT, 3 weekend shutdowns for Kendall/MIT-Park).

## Changes

<img width="1645" alt="Screenshot 2024-06-21 at 08 32 55" src="https://github.com/transitmatters/shutdown-tracker/assets/33613766/0a04fde6-303f-43f1-91b2-ac6ac52f78e3">


## Testing Instructions

N/A
