### PR TITLE
Add new Ashmont shutdown

### DIFF
--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -291,6 +291,13 @@
       "alert": "https://www.mbta.com/news/2024-07-18/major-red-line-braintree-branch-improvement-work-take-place-september-6-29-mbta"
     },
     {
+      "start_station": "JFK/UMass (Ashmont)",
+      "end_station": "Ashmont",
+      "start_date": "2024-09-28",
+      "stop_date": "2024-09-29",
+      "alert": "https://www.mbta.com/news/2024-09-25/red-line-service-suspension-expanded-include-ashmont-branch-saturday-only-september"
+    },
+    {
       "start_station": "Quincy Center",
       "end_station": "Braintree",
       "start_date": "2024-11-03",


### PR DESCRIPTION
## Motivation

Add new Ashmont shutdown: https://www.mbta.com/news/2024-09-25/red-line-service-suspension-expanded-include-ashmont-branch-saturday-only-september

## Changes

- Add new https://www.mbta.com/news/2024-09-25/red-line-service-suspension-expanded-include-ashmont-branch-saturday-only-september

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
