### PR TITLE
Adding H1 2025 shutdowns to tracker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,8 +55,7 @@ jobs:
           aws_access_key_id = $AWS_ACCESS_KEY_ID
           aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
           EOF
+      - name: Install npm dependencies
+        run: npm ci
       - name: Run deploy shell script
-        run: |
-          npm ci
-          npm run build
-          bash deploy.sh
+        run: bash deploy.sh

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -338,6 +338,20 @@
       "start_date": "2025-01-25",
       "stop_date": "2025-01-26",
       "alert": "https://www.mbta.com/news/2024-12-26/mbta-announces-january-service-changes"
+    },
+    {
+      "start_station": "JFK/UMass (Ashmont)",
+      "end_station": "Ashmont",
+      "start_date": "2025-03-29",
+      "stop_date": "2025-04-06",
+      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
+    },
+    {
+      "start_station": "Alewife",
+      "end_station": "Kendall/MIT",
+      "start_date": "2025-06-07",
+      "stop_date": "2025-06-15",
+      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
     }
   ],
   "orange": [
@@ -501,6 +515,20 @@
       "start_date": "2025-01-31",
       "stop_date": "2025-02-02",
       "alert": "https://www.mbta.com/news/2024-12-26/mbta-announces-january-service-changes"
+    },
+    {
+      "start_station": "Oak Grove",
+      "end_station": "North Station",
+      "start_date": "2025-05-10",
+      "stop_date": "2025-05-18",
+      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Forest Hills",
+      "start_date": "2025-06-21",
+      "stop_date": "2025-06-29",
+      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
     }
   ],
   "blue": [


### PR DESCRIPTION
## Motivation

https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025

## Changes

Adds new shutdowns announced

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
