### PR TITLE
data: add 2025 planned red/orange/green/blue shutdowns

### DIFF
--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -79,7 +79,7 @@ export const LineGraph: React.FunctionComponent<LineGraphProps> = ({ line: selec
               .filter((sd) =>
                 range === 'upcoming'
                   ? dayjs(new Date()).isBefore(dayjs(sd.stop_date)) &&
-                    dayjs(sd.stop_date).isBefore(dayjs(new Date()).add(3, 'months'))
+                    dayjs(sd.stop_date).isBefore(dayjs(new Date()).add(12, 'months'))
                   : range === 'past'
                     ? dayjs(new Date()).isAfter(dayjs(sd.start_date))
                     : true
@@ -153,7 +153,7 @@ export const LineGraph: React.FunctionComponent<LineGraphProps> = ({ line: selec
                 max:
                   range === 'past'
                     ? dayjs(new Date()).toISOString()
-                    : dayjs(new Date()).add(2, 'months').toISOString(),
+                    : dayjs(new Date()).add(12, 'months').toISOString(),
                 time: { unit: 'month' },
                 adapters: {
                   date: {

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -79,7 +79,7 @@ export const LineGraph: React.FunctionComponent<LineGraphProps> = ({ line: selec
               .filter((sd) =>
                 range === 'upcoming'
                   ? dayjs(new Date()).isBefore(dayjs(sd.stop_date)) &&
-                    dayjs(sd.stop_date).isBefore(dayjs(new Date()).add(12, 'months'))
+                    dayjs(sd.stop_date).isBefore(dayjs(new Date()).add(11, 'months'))
                   : range === 'past'
                     ? dayjs(new Date()).isAfter(dayjs(sd.start_date))
                     : true
@@ -153,7 +153,7 @@ export const LineGraph: React.FunctionComponent<LineGraphProps> = ({ line: selec
                 max:
                   range === 'past'
                     ? dayjs(new Date()).toISOString()
-                    : dayjs(new Date()).add(12, 'months').toISOString(),
+                    : dayjs(new Date()).add(11, 'months').toISOString(),
                 time: { unit: 'month' },
                 adapters: {
                   date: {

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -153,7 +153,7 @@ export const LineGraph: React.FunctionComponent<LineGraphProps> = ({ line: selec
                 max:
                   range === 'past'
                     ? dayjs(new Date()).toISOString()
-                    : dayjs(new Date()).add(11, 'months').toISOString(),
+                    : dayjs(new Date()).add(10, 'months').toISOString(),
                 time: { unit: 'month' },
                 adapters: {
                   date: {

--- a/src/components/LineGraph.tsx
+++ b/src/components/LineGraph.tsx
@@ -56,7 +56,7 @@ export const LineGraph: React.FunctionComponent<LineGraphProps> = ({ line: selec
               shutdowns.filter((sd) =>
                 range === 'upcoming'
                   ? dayjs(new Date()).isBefore(dayjs(sd.stop_date)) &&
-                    dayjs(sd.stop_date).isBefore(dayjs(new Date()).add(3, 'months'))
+                    dayjs(sd.stop_date).isBefore(dayjs(new Date()).add(11, 'months'))
                   : range === 'past'
                     ? dayjs(new Date()).isAfter(dayjs(sd.start_date))
                     : true

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -184,6 +184,20 @@
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
+      "start_station": "South Street",
+      "end_station": "Boston College",
+      "start_date": "2025-04-11",
+      "stop_date": "2025-04-13",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "South Street",
+      "end_station": "Boston College",
+      "start_date": "2025-05-02",
+      "stop_date": "2025-05-04",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
       "start_station": "North Station",
       "end_station": "Kenmore",
       "start_date": "2025-05-30",
@@ -226,31 +240,17 @@
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "North Station",
-      "end_station": "Copley",
-      "start_date": "2025-12-08",
-      "stop_date": "2025-12-21",
+      "start_station": "Government Center",
+      "end_station": "Union Square",
+      "start_date": "2025-06-13",
+      "stop_date": "2025-06-15",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "Copley",
-      "end_station": "Babcock Street",
-      "start_date": "2025-11-01",
-      "stop_date": "2025-11-09",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Copley",
-      "end_station": "Cleveland Circle",
-      "start_date": "2025-11-01",
-      "stop_date": "2025-11-09",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Copley",
-      "end_station": "Brookline Hills",
-      "start_date": "2025-11-01",
-      "stop_date": "2025-11-09",
+      "start_station": "Government Center",
+      "end_station": "East Somerville",
+      "start_date": "2025-06-13",
+      "stop_date": "2025-06-15",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -289,31 +289,31 @@
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "Government Center",
-      "end_station": "Union Square",
-      "start_date": "2025-06-13",
-      "stop_date": "2025-06-15",
+      "start_station": "Copley",
+      "end_station": "Babcock Street",
+      "start_date": "2025-11-01",
+      "stop_date": "2025-11-09",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "Government Center",
-      "end_station": "East Somerville",
-      "start_date": "2025-06-13",
-      "stop_date": "2025-06-15",
+      "start_station": "Copley",
+      "end_station": "Cleveland Circle",
+      "start_date": "2025-11-01",
+      "stop_date": "2025-11-09",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "South Street",
-      "end_station": "Boston College",
-      "start_date": "2025-04-11",
-      "stop_date": "2025-04-13",
+      "start_station": "Copley",
+      "end_station": "Brookline Hills",
+      "start_date": "2025-11-01",
+      "stop_date": "2025-11-09",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "South Street",
-      "end_station": "Boston College",
-      "start_date": "2025-05-02",
-      "stop_date": "2025-05-04",
+      "start_station": "North Station",
+      "end_station": "Copley",
+      "start_date": "2025-12-08",
+      "stop_date": "2025-12-21",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],
@@ -508,11 +508,46 @@
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
+      "start_station": "JFK/UMass (Braintree)",
+      "end_station": "Braintree",
+      "start_date": "2025-03-08",
+      "stop_date": "2025-03-09",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "JFK/UMass (Ashmont)",
+      "end_station": "Ashmont",
+      "start_date": "2025-04-01",
+      "stop_date": "2025-04-09",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-04-25",
+      "stop_date": "2025-04-27",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
       "start_station": "Alewife",
       "end_station": "Kendall/MIT",
       "start_date": "2025-06-07",
       "stop_date": "2025-06-15",
       "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
+    },
+    {
+      "start_station": "North Quincy",
+      "end_station": "Braintree",
+      "start_date": "2025-08-02",
+      "stop_date": "2025-08-10",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Broadway",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-08-09",
+      "stop_date": "2025-08-10",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
       "start_station": "Alewife",
@@ -529,17 +564,10 @@
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "Broadway",
-      "end_station": "JFK/UMass (Ashmont)",
-      "start_date": "2025-08-09",
-      "stop_date": "2025-08-10",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "JFK/UMass (Ashmont)",
+      "start_station": "Park Street",
       "end_station": "Ashmont",
-      "start_date": "2025-04-01",
-      "stop_date": "2025-04-09",
+      "start_date": "2025-12-06",
+      "stop_date": "2025-12-07",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -547,34 +575,6 @@
       "end_station": "Ashmont",
       "start_date": "2025-12-20",
       "stop_date": "2025-12-21",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "JFK/UMass (Braintree)",
-      "end_station": "Braintree",
-      "start_date": "2025-03-08",
-      "stop_date": "2025-03-09",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Kendall/MIT",
-      "end_station": "JFK/UMass (Ashmont)",
-      "start_date": "2025-04-25",
-      "stop_date": "2025-04-27",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "North Quincy",
-      "end_station": "Braintree",
-      "start_date": "2025-08-02",
-      "stop_date": "2025-08-10",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Park Street",
-      "end_station": "Ashmont",
-      "start_date": "2025-12-06",
-      "stop_date": "2025-12-07",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],
@@ -748,6 +748,27 @@
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
+      "start_station": "North Station",
+      "end_station": "Jackson Square",
+      "start_date": "2025-03-01",
+      "stop_date": "2025-03-02",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Wellington",
+      "end_station": "Back Bay",
+      "start_date": "2025-04-12",
+      "stop_date": "2025-04-13",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Wellington",
+      "end_station": "Back Bay",
+      "start_date": "2025-05-03",
+      "stop_date": "2025-05-04",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
       "start_station": "Oak Grove",
       "end_station": "North Station",
       "start_date": "2025-05-10",
@@ -759,7 +780,7 @@
       "end_station": "Forest Hills",
       "start_date": "2025-06-21",
       "stop_date": "2025-06-29",
-      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
       "start_station": "Back Bay",
@@ -795,34 +816,6 @@
       "start_date": "2025-10-18",
       "stop_date": "2025-10-19",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "North Station",
-      "end_station": "Forest Hills",
-      "start_date": "2025-06-21",
-      "stop_date": "2025-06-29",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "North Station",
-      "end_station": "Jackson Square",
-      "start_date": "2025-03-01",
-      "stop_date": "2025-03-02",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Wellington",
-      "end_station": "Back Bay",
-      "start_date": "2025-04-12",
-      "stop_date": "2025-04-13",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Wellington",
-      "end_station": "Back Bay",
-      "start_date": "2025-05-03",
-      "stop_date": "2025-05-04",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],
   "blue": [
@@ -848,17 +841,17 @@
       "alert": "https://www.mbta.com/news/2024-03-15/april-service-changes-mbta-continues-work-improve-reliability-across-the-system"
     },
     {
-      "start_station": "Airport",
-      "end_station": "Wonderland",
-      "start_date": "2025-08-16",
-      "stop_date": "2025-08-24",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
       "start_station": "Bowdoin",
       "end_station": "Airport",
       "start_date": "2025-06-07",
       "stop_date": "2025-06-15",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Airport",
+      "end_station": "Wonderland",
+      "start_date": "2025-08-16",
+      "stop_date": "2025-08-24",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ]

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -182,6 +182,139 @@
       "start_date": "2025-02-22",
       "stop_date": "2025-02-23",
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Kenmore",
+      "start_date": "2025-05-30",
+      "stop_date": "2025-06-01",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Babcock Street",
+      "start_date": "2025-05-30",
+      "stop_date": "2025-06-01",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Heath Street",
+      "start_date": "2025-05-30",
+      "stop_date": "2025-06-01",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Kenmore",
+      "start_date": "2025-06-06",
+      "stop_date": "2025-06-08",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Babcock Street",
+      "start_date": "2025-06-06",
+      "stop_date": "2025-06-08",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Heath Street",
+      "start_date": "2025-06-06",
+      "stop_date": "2025-06-08",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Copley",
+      "start_date": "2025-12-08",
+      "stop_date": "2025-12-21",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Copley",
+      "end_station": "Babcock Street",
+      "start_date": "2025-11-01",
+      "stop_date": "2025-11-09",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Copley",
+      "end_station": "Cleveland Circle",
+      "start_date": "2025-11-01",
+      "stop_date": "2025-11-09",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Copley",
+      "end_station": "Brookline Hills",
+      "start_date": "2025-11-01",
+      "stop_date": "2025-11-09",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Kenmore",
+      "end_station": "Riverside",
+      "start_date": "2025-09-20",
+      "stop_date": "2025-09-28",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Copley",
+      "end_station": "Heath Street",
+      "start_date": "2025-09-06",
+      "stop_date": "2025-09-07",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Copley",
+      "end_station": "Heath Street",
+      "start_date": "2025-10-04",
+      "stop_date": "2025-10-05",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Copley",
+      "end_station": "Heath Street",
+      "start_date": "2025-10-11",
+      "stop_date": "2025-10-13",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Copley",
+      "end_station": "Heath Street",
+      "start_date": "2025-10-25",
+      "stop_date": "2025-10-26",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Government Center",
+      "end_station": "Union Square",
+      "start_date": "2025-06-13",
+      "stop_date": "2025-06-15",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Government Center",
+      "end_station": "East Somerville",
+      "start_date": "2025-06-13",
+      "stop_date": "2025-06-15",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "South Street",
+      "end_station": "Boston College",
+      "start_date": "2025-04-11",
+      "stop_date": "2025-04-13",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "South Street",
+      "end_station": "Boston College",
+      "start_date": "2025-05-02",
+      "stop_date": "2025-05-04",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],
   "red": [
@@ -375,18 +508,74 @@
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
-      "start_station": "JFK/UMass (Ashmont)",
-      "end_station": "Ashmont",
-      "start_date": "2025-03-29",
-      "stop_date": "2025-04-06",
-      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
-    },
-    {
       "start_station": "Alewife",
       "end_station": "Kendall/MIT",
       "start_date": "2025-06-07",
       "stop_date": "2025-06-15",
       "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
+    },
+    {
+      "start_station": "Alewife",
+      "end_station": "Kendall/MIT",
+      "start_date": "2025-10-03",
+      "stop_date": "2025-10-05",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Alewife",
+      "end_station": "Kendall/MIT",
+      "start_date": "2025-10-24",
+      "stop_date": "2025-10-26",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Broadway",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-08-09",
+      "stop_date": "2025-08-10",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "JFK/UMass (Ashmont)",
+      "end_station": "Ashmont",
+      "start_date": "2025-04-01",
+      "stop_date": "2025-04-09",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "JFK/UMass (Ashmont)",
+      "end_station": "Ashmont",
+      "start_date": "2025-12-20",
+      "stop_date": "2025-12-21",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "JFK/UMass (Braintree)",
+      "end_station": "Braintree",
+      "start_date": "2025-03-08",
+      "stop_date": "2025-03-09",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-04-25",
+      "stop_date": "2025-04-27",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Quincy",
+      "end_station": "Braintree",
+      "start_date": "2025-08-02",
+      "stop_date": "2025-08-10",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Park Street",
+      "end_station": "Ashmont",
+      "start_date": "2025-12-06",
+      "stop_date": "2025-12-07",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],
   "orange": [
@@ -571,6 +760,69 @@
       "start_date": "2025-06-21",
       "stop_date": "2025-06-29",
       "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-07-26",
+      "stop_date": "2025-07-27",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-08-02",
+      "stop_date": "2025-08-03",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-08-16",
+      "stop_date": "2025-08-17",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-08-23",
+      "stop_date": "2025-08-24",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-10-18",
+      "stop_date": "2025-10-19",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Forest Hills",
+      "start_date": "2025-06-21",
+      "stop_date": "2025-06-29",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Jackson Square",
+      "start_date": "2025-03-01",
+      "stop_date": "2025-03-02",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Wellington",
+      "end_station": "Back Bay",
+      "start_date": "2025-04-12",
+      "stop_date": "2025-04-13",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Wellington",
+      "end_station": "Back Bay",
+      "start_date": "2025-05-03",
+      "stop_date": "2025-05-04",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],
   "blue": [
@@ -594,6 +846,20 @@
       "start_date": "2024-04-20",
       "stop_date": "2024-04-30",
       "alert": "https://www.mbta.com/news/2024-03-15/april-service-changes-mbta-continues-work-improve-reliability-across-the-system"
+    },
+    {
+      "start_station": "Airport",
+      "end_station": "Wonderland",
+      "start_date": "2025-08-16",
+      "stop_date": "2025-08-24",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Bowdoin",
+      "end_station": "Airport",
+      "start_date": "2025-06-07",
+      "stop_date": "2025-06-15",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ]
 }


### PR DESCRIPTION

<img width="1049" alt="image" src="https://github.com/user-attachments/assets/58f5b39e-11a1-4d02-99f9-ea407ccb4de9" />


## Motivation

Closes #98 

## Changes

Adds shutdown data for the Red, Orange, Blue, and Green lines per [the MBTA's schedule](https://www.mbta.com/projects/2025-planned-closures). 

This excludes the one Mattapan line shutdown, Silver Line, and Commuter Rail since the tracker doesn't support those modes at this point, but could in a followup. Also, we can add the Shutdown Reason in a followup, tracked in #99 

