### PR TITLE
Add shutdown reasons

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -60,9 +60,20 @@ def calendar():
             )
             event.add("name", event_name)
             event.add("summary", event_name)
+
+            description_paragraphs = [
+                f"The MBTA {line.capitalize()} Line will be shut down between {shutdown['start_station']} and {shutdown['end_station']}."
+            ]
+
+            reason = shutdown.get("reason")
+            if reason:
+                description_paragraphs.append(f"Reason: {reason}")
+
+            description_paragraphs.append(f"Read more at {shutdown['alert']}")
+
             event.add(
                 "description",
-                f"The MBTA {line.capitalize()} Line will be shut down between {shutdown['start_station']} and {shutdown['end_station']}. During this time the MBTA plans to make repairs and improvements to the line, and hopefully improve service. Read more at {shutdown['alert']}",
+                "\n\n".join(description_paragraphs),
             )
 
             # Handle dates (set end date to day after stop date to include the whole day in the event)

--- a/src/components/Shutdowns/ShutdownDetails.tsx
+++ b/src/components/Shutdowns/ShutdownDetails.tsx
@@ -5,30 +5,23 @@ import { abbreviateStationName } from '../../constants/stations';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { Lines } from '../../store';
 import { useTripExplorerQueries } from '../../api/traveltimes';
-import { Station } from '../../types';
+import { Shutdown, Station } from '../../types';
 import { stopIdsForStations } from '../../utils/stations';
 import { cardStyles } from '../../constants/styles';
 import { colorToStyle } from '../../styles';
-import { shutdowns } from '../../constants/shutdowns';
 import ChartContainer from './ChartContainer';
 import ShutdownMap from './ShutdownMap';
 import StatusBadge from './StatusBadge';
 
 interface ShutdownDetailsProps {
   line: Lines;
+  shutdown: Shutdown;
   handleBack: () => void;
-  start_date: string;
-  end_date: string;
-  start_station: string;
-  end_station: string;
 }
 
 const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
   line,
-  start_date,
-  end_date,
-  start_station,
-  end_station,
+  shutdown,
   handleBack,
 }) => {
   const [isReversed, setIsReversed] = useState(false);
@@ -37,15 +30,6 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
   const isMobile = useBreakpoint('sm');
   const displayStationName = (station: Station) =>
     isMobile ? station.stop_name : abbreviateStationName(station.stop_name);
-
-  const shutdown = shutdowns[line].find((shutdown) => {
-    return (
-      shutdown.start_date === start_date &&
-      shutdown.stop_date === end_date &&
-      shutdown.start_station?.stop_name === start_station &&
-      shutdown.end_station?.stop_name === end_station
-    );
-  })!;
 
   const handleToggleDirection = () => {
     setIsReversed((prev) => !prev);
@@ -59,7 +43,7 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
       <div className={`flex flex-row justify-between pb-3 ${cardStyles}`}>
         <div className="flex flex-col items-start">
           <div className="text-base md:text-2xl items-center flex flex-row dark:text-white">
-            <h3>{`${shutdown.start_station ? displayStationName(shutdown.start_station) : start_station} - ${shutdown.end_station ? displayStationName(shutdown.end_station) : end_station}`}</h3>
+            <h3>{`${displayStationName(shutdown.start_station)} - ${displayStationName(shutdown.end_station)}`}</h3>
             <StatusBadge start_date={shutdown.start_date} stop_date={shutdown.stop_date} />
           </div>
           <div className="mt-1 text-gray-500 dark:text-slate-400">

--- a/src/components/Shutdowns/ShutdownDetails.tsx
+++ b/src/components/Shutdowns/ShutdownDetails.tsx
@@ -5,10 +5,11 @@ import { abbreviateStationName } from '../../constants/stations';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { Lines } from '../../store';
 import { useTripExplorerQueries } from '../../api/traveltimes';
-import { Shutdown, Station } from '../../types';
-import { getStationByName, stopIdsForStations } from '../../utils/stations';
+import { Station } from '../../types';
+import { stopIdsForStations } from '../../utils/stations';
 import { cardStyles } from '../../constants/styles';
 import { colorToStyle } from '../../styles';
+import { shutdowns } from '../../constants/shutdowns';
 import ChartContainer from './ChartContainer';
 import ShutdownMap from './ShutdownMap';
 import StatusBadge from './StatusBadge';
@@ -37,15 +38,14 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
   const displayStationName = (station: Station) =>
     isMobile ? station.stop_name : abbreviateStationName(station.stop_name);
 
-  const startStation = getStationByName(start_station, line);
-  const endStation = getStationByName(end_station, line);
-
-  const shutdown: Shutdown = {
-    start_date,
-    stop_date: end_date,
-    start_station: startStation,
-    end_station: endStation,
-  };
+  const shutdown = shutdowns[line].find((shutdown) => {
+    return (
+      shutdown.start_date === start_date &&
+      shutdown.stop_date === end_date &&
+      shutdown.start_station?.stop_name === start_station &&
+      shutdown.end_station?.stop_name === end_station
+    );
+  })!;
 
   const handleToggleDirection = () => {
     setIsReversed((prev) => !prev);
@@ -67,6 +67,11 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
               {formatDate(shutdown.start_date)} - {formatDate(shutdown.stop_date)}
             </p>
           </div>
+          {shutdown.reason && (
+            <div className="mt-1 text-gray-500 dark:text-slate-400">
+              <p>Reason: {shutdown.reason}</p>
+            </div>
+          )}
         </div>
         <div className="flex justify-center items-start h-full">
           <button

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -166,6 +166,7 @@
       "end_station": "Babcock Street",
       "start_date": "2025-02-22",
       "stop_date": "2025-02-23",
+      "reason": "Regular maintenance",
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
@@ -173,6 +174,7 @@
       "end_station": "Heath Street",
       "start_date": "2025-02-22",
       "stop_date": "2025-02-23",
+      "reason": "Regular maintenance",
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
@@ -180,6 +182,7 @@
       "end_station": "Kenmore",
       "start_date": "2025-02-22",
       "stop_date": "2025-02-23",
+      "reason": "Regular maintenance",
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
@@ -187,6 +190,7 @@
       "end_station": "Boston College",
       "start_date": "2025-04-11",
       "stop_date": "2025-04-13",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -194,6 +198,7 @@
       "end_station": "Boston College",
       "start_date": "2025-05-02",
       "stop_date": "2025-05-04",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -201,6 +206,7 @@
       "end_station": "Babcock Street",
       "start_date": "2025-05-30",
       "stop_date": "2025-06-01",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -208,6 +214,7 @@
       "end_station": "Heath Street",
       "start_date": "2025-05-30",
       "stop_date": "2025-06-01",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -215,6 +222,7 @@
       "end_station": "Kenmore",
       "start_date": "2025-05-30",
       "stop_date": "2025-06-01",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -222,6 +230,7 @@
       "end_station": "Babcock Street",
       "start_date": "2025-06-06",
       "stop_date": "2025-06-08",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -229,6 +238,7 @@
       "end_station": "Heath Street",
       "start_date": "2025-06-06",
       "stop_date": "2025-06-08",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -236,6 +246,7 @@
       "end_station": "Kenmore",
       "start_date": "2025-06-06",
       "stop_date": "2025-06-08",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -243,6 +254,7 @@
       "end_station": "East Somerville",
       "start_date": "2025-06-13",
       "stop_date": "2025-06-15",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -250,6 +262,7 @@
       "end_station": "Union Square",
       "start_date": "2025-06-13",
       "stop_date": "2025-06-15",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -257,6 +270,7 @@
       "end_station": "Heath Street",
       "start_date": "2025-09-06",
       "stop_date": "2025-09-07",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -264,6 +278,7 @@
       "end_station": "Riverside",
       "start_date": "2025-09-20",
       "stop_date": "2025-09-28",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -271,6 +286,7 @@
       "end_station": "Heath Street",
       "start_date": "2025-10-04",
       "stop_date": "2025-10-05",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -278,6 +294,7 @@
       "end_station": "Heath Street",
       "start_date": "2025-10-11",
       "stop_date": "2025-10-13",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -285,6 +302,7 @@
       "end_station": "Heath Street",
       "start_date": "2025-10-25",
       "stop_date": "2025-10-26",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -292,6 +310,7 @@
       "end_station": "Babcock Street",
       "start_date": "2025-11-01",
       "stop_date": "2025-11-09",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -299,6 +318,7 @@
       "end_station": "Brookline Hills",
       "start_date": "2025-11-01",
       "stop_date": "2025-11-09",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -306,6 +326,7 @@
       "end_station": "Cleveland Circle",
       "start_date": "2025-11-01",
       "stop_date": "2025-11-09",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -313,6 +334,7 @@
       "end_station": "Copley",
       "start_date": "2025-12-08",
       "stop_date": "2025-12-21",
+      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -782,6 +782,7 @@
       "end_station": "North Station",
       "start_date": "2025-01-17",
       "stop_date": "2025-01-20",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement",
       "alert": "https://www.mbta.com/news/2024-12-26/mbta-announces-january-service-changes"
     },
     {
@@ -789,6 +790,7 @@
       "end_station": "North Station",
       "start_date": "2025-01-31",
       "stop_date": "2025-02-02",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement",
       "alert": "https://www.mbta.com/news/2024-12-26/mbta-announces-january-service-changes"
     },
     {
@@ -796,6 +798,7 @@
       "end_station": "North Station",
       "start_date": "2025-02-14",
       "stop_date": "2025-02-17",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement",
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
@@ -803,13 +806,23 @@
       "end_station": "Jackson Square",
       "start_date": "2025-03-01",
       "stop_date": "2025-03-02",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Oak Grove",
+      "end_station": "North Station",
+      "start_date": "2025-03-07",
+      "stop_date": "2025-03-09",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement",
+      "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
       "start_station": "Wellington",
       "end_station": "Back Bay",
       "start_date": "2025-04-12",
       "stop_date": "2025-04-13",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -817,6 +830,7 @@
       "end_station": "Back Bay",
       "start_date": "2025-05-03",
       "stop_date": "2025-05-04",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -824,6 +838,7 @@
       "end_station": "North Station",
       "start_date": "2025-05-10",
       "stop_date": "2025-05-18",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement",
       "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
     },
     {
@@ -831,13 +846,15 @@
       "end_station": "Forest Hills",
       "start_date": "2025-06-21",
       "stop_date": "2025-06-29",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+      "reason": "Signal upgrades",
+      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
     },
     {
       "start_station": "Back Bay",
       "end_station": "Forest Hills",
       "start_date": "2025-07-26",
       "stop_date": "2025-07-27",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -845,6 +862,7 @@
       "end_station": "Forest Hills",
       "start_date": "2025-08-02",
       "stop_date": "2025-08-03",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -852,6 +870,7 @@
       "end_station": "Forest Hills",
       "start_date": "2025-08-16",
       "stop_date": "2025-08-17",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -859,6 +878,23 @@
       "end_station": "Forest Hills",
       "start_date": "2025-08-23",
       "stop_date": "2025-08-24",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Forest Hills",
+      "start_date": "2025-09-13",
+      "stop_date": "2025-09-14",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "North Station",
+      "end_station": "Forest Hills",
+      "start_date": "2025-09-27",
+      "stop_date": "2025-09-28",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -866,6 +902,23 @@
       "end_station": "Forest Hills",
       "start_date": "2025-10-18",
       "stop_date": "2025-10-19",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-11-01",
+      "stop_date": "2025-11-02",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-11-22",
+      "stop_date": "2025-11-23",
+      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -971,6 +971,7 @@
       "end_station": "Airport",
       "start_date": "2025-06-07",
       "stop_date": "2025-06-15",
+      "reason": "Regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -978,6 +979,7 @@
       "end_station": "Wonderland",
       "start_date": "2025-08-16",
       "stop_date": "2025-08-24",
+      "reason": "Regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ]

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -564,13 +564,6 @@
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
-      "start_station": "Alewife",
-      "end_station": "Kendall/MIT",
-      "start_date": "2025-06-07",
-      "stop_date": "2025-06-15",
-      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
-    },
-    {
       "start_station": "Kendall/MIT",
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-07-10",

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -490,6 +490,7 @@
       "end_station": "Braintree",
       "start_date": "2025-01-25",
       "stop_date": "2025-01-26",
+      "reason": "Signal upgrades",
       "alert": "https://www.mbta.com/news/2024-12-26/mbta-announces-january-service-changes"
     },
     {
@@ -497,6 +498,7 @@
       "end_station": "Braintree",
       "start_date": "2025-02-08",
       "stop_date": "2025-02-09",
+      "reason": "Signal upgrades",
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
@@ -504,6 +506,7 @@
       "end_station": "Braintree",
       "start_date": "2025-02-22",
       "stop_date": "2025-02-23",
+      "reason": "Signal upgrades",
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
@@ -511,6 +514,15 @@
       "end_station": "Braintree",
       "start_date": "2025-03-08",
       "stop_date": "2025-03-09",
+      "reason": "Signal upgrades, annual programmed maintenance",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "JFK/UMass (Braintree)",
+      "end_station": "Braintree",
+      "start_date": "2025-03-29",
+      "stop_date": "2025-03-30",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -518,6 +530,7 @@
       "end_station": "Ashmont",
       "start_date": "2025-04-01",
       "stop_date": "2025-04-09",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -525,6 +538,7 @@
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-04-25",
       "stop_date": "2025-04-27",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -535,10 +549,27 @@
       "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
     },
     {
+      "start_station": "Kendall/MIT",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-07-10",
+      "stop_date": "2025-07-13",
+      "reason": "Signal upgrades, annual programmed maintenance",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-07-17",
+      "stop_date": "2025-07-20",
+      "reason": "Signal upgrades, annual programmed maintenance",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
       "start_station": "North Quincy",
       "end_station": "Braintree",
       "start_date": "2025-08-02",
       "stop_date": "2025-08-10",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -546,6 +577,7 @@
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-08-09",
       "stop_date": "2025-08-10",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -553,6 +585,7 @@
       "end_station": "Kendall/MIT",
       "start_date": "2025-10-03",
       "stop_date": "2025-10-05",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -560,6 +593,15 @@
       "end_station": "Kendall/MIT",
       "start_date": "2025-10-24",
       "stop_date": "2025-10-26",
+      "reason": "Signal upgrades, annual programmed maintenance",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-11-14",
+      "stop_date": "2025-11-16",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -567,6 +609,15 @@
       "end_station": "Ashmont",
       "start_date": "2025-12-06",
       "stop_date": "2025-12-07",
+      "reason": "Signal upgrades, annual programmed maintenance",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Park Street",
+      "end_station": "North Quincy",
+      "start_date": "2025-12-06",
+      "stop_date": "2025-12-07",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -574,6 +625,7 @@
       "end_station": "Ashmont",
       "start_date": "2025-12-20",
       "stop_date": "2025-12-21",
+      "reason": "Signal upgrades, annual programmed maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -514,7 +514,7 @@
       "end_station": "Braintree",
       "start_date": "2025-03-08",
       "stop_date": "2025-03-09",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -522,7 +522,7 @@
       "end_station": "Braintree",
       "start_date": "2025-03-29",
       "stop_date": "2025-03-30",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -530,7 +530,7 @@
       "end_station": "Ashmont",
       "start_date": "2025-04-01",
       "stop_date": "2025-04-09",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -538,7 +538,7 @@
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-04-25",
       "stop_date": "2025-04-27",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -553,7 +553,7 @@
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-07-10",
       "stop_date": "2025-07-13",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -561,7 +561,7 @@
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-07-17",
       "stop_date": "2025-07-20",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -569,7 +569,7 @@
       "end_station": "Braintree",
       "start_date": "2025-08-02",
       "stop_date": "2025-08-10",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -577,7 +577,7 @@
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-08-09",
       "stop_date": "2025-08-10",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -585,7 +585,7 @@
       "end_station": "Kendall/MIT",
       "start_date": "2025-10-03",
       "stop_date": "2025-10-05",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -593,7 +593,7 @@
       "end_station": "Kendall/MIT",
       "start_date": "2025-10-24",
       "stop_date": "2025-10-26",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -601,7 +601,7 @@
       "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-11-14",
       "stop_date": "2025-11-16",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -609,7 +609,7 @@
       "end_station": "Ashmont",
       "start_date": "2025-12-06",
       "stop_date": "2025-12-07",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -617,7 +617,7 @@
       "end_station": "North Quincy",
       "start_date": "2025-12-06",
       "stop_date": "2025-12-07",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
@@ -625,7 +625,7 @@
       "end_station": "Ashmont",
       "start_date": "2025-12-20",
       "stop_date": "2025-12-21",
-      "reason": "Signal upgrades, annual programmed maintenance",
+      "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
     }
   ],

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -552,8 +552,8 @@
       "end_station": "Ashmont",
       "start_date": "2025-04-01",
       "stop_date": "2025-04-09",
-      "reason": "Signal upgrades, regular maintenance",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+      "reason": "Proactive rail maintenance",
+      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
     },
     {
       "start_station": "Kendall/MIT",
@@ -964,8 +964,8 @@
       "end_station": "Airport",
       "start_date": "2025-06-07",
       "stop_date": "2025-06-15",
-      "reason": "Regular maintenance",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
+      "reason": "Infrastructure work",
+      "alert": "https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025"
     },
     {
       "start_station": "Airport",

--- a/src/routes/$line/index.tsx
+++ b/src/routes/$line/index.tsx
@@ -9,6 +9,7 @@ import { Lines } from '../../store';
 import { LineButtons } from '../../components/LineButtons';
 import Footer from '../../components/Footer';
 import { RangeButtons } from '../../components/RangeButtons';
+import { shutdowns } from '../../constants/shutdowns';
 
 interface SearchParams {
   start_station?: string;
@@ -33,6 +34,22 @@ function Line() {
   const router = useRouter();
   const handleBack = () => router.history.back();
 
+  const shutdown =
+    search.start_date &&
+    search.end_date &&
+    search.start_station &&
+    search.end_station &&
+    line !== 'all'
+      ? shutdowns[line].find((shutdown) => {
+          return (
+            shutdown.start_date === search.start_date &&
+            shutdown.stop_date === search.end_date &&
+            shutdown.start_station?.stop_name === search.start_station &&
+            shutdown.end_station?.stop_name === search.end_station
+          );
+        })
+      : undefined;
+
   return (
     <>
       <div
@@ -47,19 +64,8 @@ function Line() {
           <RangeButtons />
         </Navbar>
         <div className="md:px-12 p-6">
-          {search.start_date &&
-          search.end_date &&
-          search.start_station &&
-          search.end_station &&
-          line !== 'all' ? (
-            <ShutdownDetails
-              line={line}
-              start_date={search.start_date}
-              end_date={search.end_date}
-              start_station={search.start_station}
-              end_station={search.end_station}
-              handleBack={handleBack}
-            />
+          {shutdown ? (
+            <ShutdownDetails line={line as Lines} shutdown={shutdown} handleBack={handleBack} />
           ) : (
             <>
               <LineGraph line={line} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,9 +31,9 @@ export interface LineMap {
 export type Shutdown = {
   start_date: string;
   stop_date: string;
-  start_station: Station | undefined;
-  end_station: Station | undefined;
-  reason: string | undefined;
+  start_station: Station;
+  end_station: Station;
+  reason?: string;
 };
 
 export type Shutdowns = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export type Shutdown = {
   stop_date: string;
   start_station: Station | undefined;
   end_station: Station | undefined;
+  reason: string | undefined;
 };
 
 export type Shutdowns = {


### PR DESCRIPTION
Depends on https://github.com/transitmatters/shutdown-tracker/pull/101

## Motivation

https://github.com/transitmatters/shutdown-tracker/issues/99

## Changes

This PR adds the reasons for each shutdown according to the various references, such as [the yearly planned closure list](https://www.mbta.com/projects/2025-planned-closures) and [half-yearly](https://www.mbta.com/news/2025-01-17/mbta-shares-planned-service-outage-scheduled-january-june-2025) and [monthly](https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes) updates.

These reasons are currently just exposed in the descriptions of the calendar events we generate.

<img width="322" alt="image" src="https://github.com/user-attachments/assets/c595d8a6-4029-4663-a67f-900b5bb48c1b" />

I also found a couple shutdowns that weren't in the JSON, and one which was in the JSON but I couldn't find a reference to. I cleaned these up while I was in here.


## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
