### PR TITLE
Lint shutdowns.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start-python": "cd server && poetry run chalice local --port=5555",
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint-frontend": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 10",
+    "lint-frontend": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 10 && poetry run python sort-shutdowns.py --check",
     "lint-backend": "cd server && poetry run flake8 && poetry run black . --check",
     "lint": "concurrently npm:lint-frontend npm:lint-backend",
     "postinstall": "cd server && poetry install",

--- a/sort-shutdowns.py
+++ b/sort-shutdowns.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 
 def build_sort_key(shutdown):
@@ -18,6 +19,14 @@ new_data = {}
 for key in data:
     new_data[key] = sorted(data[key], key=build_sort_key)
 
-with open("src/constants/shutdowns.json", "w") as f:
-    json.dump(new_data, f, indent=2)
-    f.write("\n")
+if "--check" in sys.argv:
+    if data == new_data:
+        print("shutdowns.json is sorted")
+        sys.exit(0)
+
+    print("shutdowns.json is not sorted. Run `python sort-shutdowns.py` to sort it.")
+    sys.exit(1)
+else:
+    with open("src/constants/shutdowns.json", "w") as f:
+        json.dump(new_data, f, indent=2)
+        f.write("\n")

--- a/sort-shutdowns.py
+++ b/sort-shutdowns.py
@@ -11,6 +11,10 @@ def build_sort_key(shutdown):
     )
 
 
+def print_red(message):
+    print(f"\033[91m{message}\033[0m")
+
+
 with open("src/constants/shutdowns.json", "r") as f:
     data = json.load(f)
 
@@ -24,7 +28,7 @@ if "--check" in sys.argv:
         print("shutdowns.json is sorted")
         sys.exit(0)
 
-    print("shutdowns.json is not sorted. Run `python sort-shutdowns.py` to sort it.")
+    print_red("shutdowns.json is not sorted. Run `python sort-shutdowns.py` to sort it.")
     sys.exit(1)
 else:
     with open("src/constants/shutdowns.json", "w") as f:


### PR DESCRIPTION
## Motivation

I added a sorting script for `shutdowns.json` in https://github.com/transitmatters/shutdown-tracker/pull/101, but there's currently no enforcement that the file is sorted.

## Changes

This PR adds a check mode to the sort script and runs that as part of the `lint-frontend` task which is executed in our CI.

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
