### PR TITLE
feat: update shutdowns

### DIFF
--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -186,6 +186,36 @@
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
+      "start_station": "Boston College",
+      "end_station": "Boston College",
+      "start_date": "2025-04-11",
+      "stop_date": "2025-04-13"
+    },
+    {
+      "start_station": "Medford/Tufts",
+      "end_station": "Government Center",
+      "start_date": "2025-04-26",
+      "stop_date": "2025-04-27"
+    },
+    {
+      "start_station": "Park Street",
+      "end_station": "Government Center",
+      "start_date": "2025-04-26",
+      "stop_date": "2025-04-27"
+    },
+    {
+      "start_station": "Union Square",
+      "end_station": "Government Center",
+      "start_date": "2025-04-26",
+      "stop_date": "2025-04-27"
+    },
+    {
+      "start_station": "Boston College",
+      "end_station": "Boston College",
+      "start_date": "2025-05-02",
+      "stop_date": "2025-05-04"
+    },
+    {
       "start_station": "North Station",
       "end_station": "East Somerville",
       "start_date": "2025-06-13",
@@ -272,36 +302,6 @@
       "stop_date": "2025-12-21",
       "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Boston College",
-      "end_station": "Boston College",
-      "start_date": "2025-04-11",
-      "stop_date": "2025-04-13"
-    },
-    {
-      "start_station": "Boston College",
-      "end_station": "Boston College",
-      "start_date": "2025-05-02",
-      "stop_date": "2025-05-04"
-    },
-    {
-      "start_station": "Park Street",
-      "end_station": "Government Center",
-      "start_date": "2025-04-26",
-      "stop_date": "2025-04-27"
-    },
-    {
-      "start_station": "Union Square",
-      "end_station": "Government Center",
-      "start_date": "2025-04-26",
-      "stop_date": "2025-04-27"
-    },
-    {
-      "start_station": "Medford/Tufts",
-      "end_station": "Government Center",
-      "start_date": "2025-04-26",
-      "stop_date": "2025-04-27"
     }
   ],
   "red": [
@@ -532,6 +532,12 @@
     {
       "start_station": "Kendall/MIT",
       "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-05-30",
+      "stop_date": "2025-06-01"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "JFK/UMass (Ashmont)",
       "start_date": "2025-07-10",
       "stop_date": "2025-07-13",
       "reason": "Signal upgrades, regular maintenance",
@@ -600,12 +606,6 @@
       "stop_date": "2025-12-21",
       "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Kendall/MIT",
-      "end_station": "JFK/UMass (Ashmont)",
-      "start_date": "2025-05-30",
-      "stop_date": "2025-06-01"
     }
   ],
   "orange": [
@@ -797,6 +797,12 @@
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-05-02",
+      "stop_date": "2025-05-04"
+    },
+    {
       "start_station": "Oak Grove",
       "end_station": "North Station",
       "start_date": "2025-05-09",
@@ -883,12 +889,6 @@
       "stop_date": "2025-11-23",
       "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Back Bay",
-      "end_station": "Forest Hills",
-      "start_date": "2025-05-02",
-      "stop_date": "2025-05-04"
     }
   ],
   "blue": [
@@ -930,14 +930,6 @@
       "alert": "https://www.mbta.com/news/2025-02-21/mbta-announces-march-service-changes"
     },
     {
-      "start_station": "Airport",
-      "end_station": "Wonderland",
-      "start_date": "2025-08-16",
-      "stop_date": "2025-08-24",
-      "reason": "Regular maintenance",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
       "start_station": "Bowdoin",
       "end_station": "Government Center",
       "start_date": "2025-04-11",
@@ -954,6 +946,14 @@
       "end_station": "Orient Heights",
       "start_date": "2025-06-07",
       "stop_date": "2025-06-15"
+    },
+    {
+      "start_station": "Airport",
+      "end_station": "Wonderland",
+      "start_date": "2025-08-16",
+      "stop_date": "2025-08-24",
+      "reason": "Regular maintenance",
+      "alert": "https://www.mbta.com/projects/2025-planned-closures"
     },
     {
       "start_station": "Bowdoin",

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -187,30 +187,6 @@
     },
     {
       "start_station": "North Station",
-      "end_station": "Babcock Street",
-      "start_date": "2025-06-06",
-      "stop_date": "2025-06-08",
-      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "North Station",
-      "end_station": "Heath Street",
-      "start_date": "2025-06-06",
-      "stop_date": "2025-06-08",
-      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "North Station",
-      "end_station": "Kenmore",
-      "start_date": "2025-06-06",
-      "stop_date": "2025-06-08",
-      "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "North Station",
       "end_station": "East Somerville",
       "start_date": "2025-06-13",
       "stop_date": "2025-06-15",
@@ -296,6 +272,36 @@
       "stop_date": "2025-12-21",
       "reason": "Tunnel inspections, regular maintenance, Symphony Station accessibility improvements, catenary trough removal",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Boston College",
+      "end_station": "Boston College",
+      "start_date": "2025-04-11",
+      "stop_date": "2025-04-13"
+    },
+    {
+      "start_station": "Boston College",
+      "end_station": "Boston College",
+      "start_date": "2025-05-02",
+      "stop_date": "2025-05-04"
+    },
+    {
+      "start_station": "Park Street",
+      "end_station": "Government Center",
+      "start_date": "2025-04-26",
+      "stop_date": "2025-04-27"
+    },
+    {
+      "start_station": "Union Square",
+      "end_station": "Government Center",
+      "start_date": "2025-04-26",
+      "stop_date": "2025-04-27"
+    },
+    {
+      "start_station": "Medford/Tufts",
+      "end_station": "Government Center",
+      "start_date": "2025-04-26",
+      "stop_date": "2025-04-27"
     }
   ],
   "red": [
@@ -594,6 +600,12 @@
       "stop_date": "2025-12-21",
       "reason": "Signal upgrades, regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Kendall/MIT",
+      "end_station": "JFK/UMass (Ashmont)",
+      "start_date": "2025-05-30",
+      "stop_date": "2025-06-01"
     }
   ],
   "orange": [
@@ -785,22 +797,6 @@
       "alert": "https://www.mbta.com/news/2025-01-22/mbta-announces-february-service-changes"
     },
     {
-      "start_station": "Wellington",
-      "end_station": "Back Bay",
-      "start_date": "2025-04-12",
-      "stop_date": "2025-04-13",
-      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
-      "start_station": "Wellington",
-      "end_station": "Back Bay",
-      "start_date": "2025-05-03",
-      "stop_date": "2025-05-04",
-      "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
-      "alert": "https://www.mbta.com/projects/2025-planned-closures"
-    },
-    {
       "start_station": "Oak Grove",
       "end_station": "North Station",
       "start_date": "2025-05-09",
@@ -887,6 +883,12 @@
       "stop_date": "2025-11-23",
       "reason": "Support Maffa Way/Mystic Avenue Bridge replacement, signal upgrades",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Back Bay",
+      "end_station": "Forest Hills",
+      "start_date": "2025-05-02",
+      "stop_date": "2025-05-04"
     }
   ],
   "blue": [
@@ -934,6 +936,36 @@
       "stop_date": "2025-08-24",
       "reason": "Regular maintenance",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Bowdoin",
+      "end_station": "Government Center",
+      "start_date": "2025-04-11",
+      "stop_date": "2025-04-14"
+    },
+    {
+      "start_station": "Bowdoin",
+      "end_station": "Government Center",
+      "start_date": "2025-04-25",
+      "stop_date": "2025-04-28"
+    },
+    {
+      "start_station": "Bowdoin",
+      "end_station": "Orient Heights",
+      "start_date": "2025-06-07",
+      "stop_date": "2025-06-15"
+    },
+    {
+      "start_station": "Bowdoin",
+      "end_station": "Airport",
+      "start_date": "2025-11-14",
+      "stop_date": "2025-11-16"
+    },
+    {
+      "start_station": "Bowdoin",
+      "end_station": "Airport",
+      "start_date": "2025-11-21",
+      "stop_date": "2025-11-23"
     }
   ]
 }


### PR DESCRIPTION
## Motivation
- Update shutdowns with latest info from COB

##
```
GREEN LINE:
Boston College Station Closed (4/11-4/13)
Park St to Government Center (B & C Branches) service suspended (4/26-4/27)
Union Sq to Government Center (D Branch) service suspended (4/26-4/27)
Medford/Tufts to Government Center (E Branch) service suspended (4/26-4/27)
Boston College Station Closed (5/2-5/4)
North Station to Heath St/Babcock St/Kenmore is NOT occurring (6/6-6/8)

RED LINE:
Kendall/MIT to JFK/UMass service suspended (5/30-6/1)

BLUE LINE:
Bowdoin to Government Center service suspended (4/11-4/14)
Bowdoin to Government Center service suspended (4/25-4/28)
Bowdoin to Orient Heights service suspended (6/7-6/15)
Bowdoin to Airport service suspended (11/14-11/16)
Bowdoin to Airport service suspended (11/21-11/23)

ORANGE LINE:
Wellington to Back Bay shutdown is NOT occurring (4/12-4/13)
Wellington to Back Bay shutdown is NOT occurring (5/3-5/4)
Back Bay to Forest Hills service suspended (5/2-5/4)
```
<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
