### PR TITLE
feat: show 14 days of data

### DIFF
--- a/src/components/Shutdowns/ChartContainer.tsx
+++ b/src/components/Shutdowns/ChartContainer.tsx
@@ -7,6 +7,7 @@ import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { getFormattedTimeValue } from '../../utils/time';
 import { Lines } from '../../store';
 import { filterPeakData } from '../../utils/travelTimes';
+import dayjs from 'dayjs';
 
 interface ChartContainerProps {
   shutdown: Shutdown;
@@ -18,6 +19,10 @@ interface ChartContainerProps {
 
 const ChartContainer = ({ before, after, line, shutdown, title }: ChartContainerProps) => {
   const isMobile = useBreakpoint('sm');
+  const isFutureShutdown = dayjs().isBefore(dayjs(shutdown.start_date));
+  const isOngoingShutdown =
+    dayjs().isAfter(dayjs(shutdown.start_date)) && dayjs().isBefore(dayjs(shutdown.stop_date));
+  const isFinishedShutdown = dayjs().isAfter(dayjs(shutdown.stop_date));
 
   const beforeData = before.isSuccess ? filterPeakData(before.data!.by_date) : [];
   const afterData = after.isSuccess ? filterPeakData(after.data!.by_date) : [];
@@ -41,12 +46,29 @@ const ChartContainer = ({ before, after, line, shutdown, title }: ChartContainer
   return (
     <div className="flex md:flex-row flex-col gap-4 h-1/3">
       <div className={`flex-1 ${cardStyles}`}>
-        <div className="text-xl">{title}</div>
+        <div className="text-xl flex items-center">
+          {title}
+          {isFutureShutdown && (
+            <span className="ml-2 text-sm bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-100 py-0.5 px-2 rounded-full">
+              Upcoming
+            </span>
+          )}
+          {isOngoingShutdown && (
+            <span className="ml-2 text-sm bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-100 py-0.5 px-2 rounded-full">
+              Ongoing
+            </span>
+          )}
+          {isFinishedShutdown && (
+            <span className="ml-2 text-sm bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-100 py-0.5 px-2 rounded-full">
+              Completed
+            </span>
+          )}
+        </div>
         <div className="h-[350px] mt-3">
           <TravelTimesChart before={before} after={after} line={line} shutdown={shutdown} />
         </div>
       </div>
-      <div className="flex md:flex-col flex-row flex-wrap md:gap-4 gap-2  ">
+      <div className="flex md:flex-col flex-row flex-wrap md:gap-4 gap-2">
         <div className={`flex flex-col flex-1 ${cardStyles} justify-center text-center`}>
           <dt className="md:truncate text-sm font-medium text-gray-700 dark:text-white align-middle ">
             {!isMobile ? 'Before' : 'Before shutdown'}
@@ -55,19 +77,41 @@ const ChartContainer = ({ before, after, line, shutdown, title }: ChartContainer
             {getFormattedTimeValue(beforeAvg, !!isMobile)}
           </dd>
         </div>
-        <div className={`flex flex-col flex-1 ${cardStyles} justify-center text-center`}>
+        <div className={`flex flex-col flex-1 ${cardStyles} justify-center text-center relative`}>
           <dt className="md:truncate text-sm font-medium text-gray-700 dark:text-white">
             {' '}
             {!isMobile ? 'After' : 'After shutdown'}
           </dt>
           <dd className="mt-1 text-xl md:text-3xl font-semibold tracking-tight">
-            {getFormattedTimeValue(afterAvg, !!isMobile)}
+            {isFutureShutdown ? (
+              <span className="text-purple-500 dark:text-purple-400">Pending</span>
+            ) : isOngoingShutdown ? (
+              <span className="text-amber-500 dark:text-amber-400">In progress</span>
+            ) : (
+              getFormattedTimeValue(afterAvg, !!isMobile)
+            )}
           </dd>
+          {isFutureShutdown && (
+            <div className="absolute -top-1 -right-1 bg-purple-400 text-purple-900 text-xs rounded-full w-6 h-6 flex items-center justify-center">
+              🔜
+            </div>
+          )}
+          {isOngoingShutdown && (
+            <div className="absolute -top-1 -right-1 bg-amber-400 text-amber-900 text-xs rounded-full w-6 h-6 flex items-center justify-center">
+              🚧
+            </div>
+          )}
         </div>
         <div className={`flex flex-col flex-1 ${cardStyles} justify-center text-center`}>
           <dt className="md:truncate text-sm font-medium text-gray-700 dark:text-white">Change</dt>
           <dd className="mt-1 text-xl md:text-3xl font-semibold tracking-tight">
-            {getFormattedTimeValue(difference, !!isMobile, direction)}
+            {isFutureShutdown ? (
+              <span className="text-purple-500 dark:text-purple-400">--</span>
+            ) : isOngoingShutdown ? (
+              <span className="text-amber-500 dark:text-amber-400">--</span>
+            ) : (
+              getFormattedTimeValue(difference, !!isMobile, direction)
+            )}
           </dd>
         </div>
       </div>

--- a/src/components/Shutdowns/ChartContainer.tsx
+++ b/src/components/Shutdowns/ChartContainer.tsx
@@ -1,13 +1,13 @@
 import type { UseQueryResult } from '@tanstack/react-query';
+import dayjs from 'dayjs';
 import { cardStyles } from '../../constants/styles';
+import { useBreakpoint } from '../../hooks/useBreakpoint';
+import { Lines } from '../../store';
 import { Shutdown } from '../../types';
+import { getFormattedTimeValue } from '../../utils/time';
+import { filterPeakData } from '../../utils/travelTimes';
 import TravelTimesChart from '../charts/TravelTimesChart';
 import { AggregateDataResponse } from '../charts/types';
-import { useBreakpoint } from '../../hooks/useBreakpoint';
-import { getFormattedTimeValue } from '../../utils/time';
-import { Lines } from '../../store';
-import { filterPeakData } from '../../utils/travelTimes';
-import dayjs from 'dayjs';
 
 interface ChartContainerProps {
   shutdown: Shutdown;

--- a/src/components/Shutdowns/ShutdownDetails.tsx
+++ b/src/components/Shutdowns/ShutdownDetails.tsx
@@ -36,6 +36,8 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
   };
 
   const isFutureShutdown = dayjs().isBefore(dayjs(shutdown.start_date));
+  const isOngoingShutdown =
+    dayjs().isAfter(dayjs(shutdown.start_date)) && dayjs().isBefore(dayjs(shutdown.stop_date));
 
   // Shutdown title card component
   const ShutdownTitleCard = () => {
@@ -86,17 +88,25 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
     to_stop: toStopIds,
   };
 
+  // For future shutdowns, query the most recent data
   const afterShutdownQueryOptions = {
     ...queryOptions,
     end_date: dayjs(shutdown.stop_date).add(14, 'day').format('YYYY-MM-DD'),
     start_date: dayjs(shutdown.stop_date).add(1, 'day').format('YYYY-MM-DD'),
   };
 
-  const beforeShutdownQueryOptions = {
-    ...queryOptions,
-    end_date: dayjs(shutdown.start_date).subtract(1, 'day').format('YYYY-MM-DD'),
-    start_date: dayjs(shutdown.start_date).subtract(14, 'day').format('YYYY-MM-DD'),
-  };
+  // For future shutdowns, we want to show the last two weeks of data
+  const beforeShutdownQueryOptions = isFutureShutdown
+    ? {
+        ...queryOptions,
+        end_date: dayjs().format('YYYY-MM-DD'),
+        start_date: dayjs().subtract(14, 'day').format('YYYY-MM-DD'),
+      }
+    : {
+        ...queryOptions,
+        end_date: dayjs(shutdown.start_date).subtract(1, 'day').format('YYYY-MM-DD'),
+        start_date: dayjs(shutdown.start_date).subtract(14, 'day').format('YYYY-MM-DD'),
+      };
 
   const beforeData = useTripExplorerQueries(beforeShutdownQueryOptions, true);
   const afterData = useTripExplorerQueries(afterShutdownQueryOptions, true);
@@ -153,14 +163,13 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
       </div>
       <div className="dark:text-white text-gray-500 text-sm">
         {isFutureShutdown ? (
-          <span>* showing {14} days of historical data before the scheduled shutdown</span>
-        ) : dayjs().isAfter(dayjs(shutdown.start_date)) &&
-          dayjs().isBefore(dayjs(shutdown.stop_date)) ? (
+          <span>* showing the last 14 days of historical data before the scheduled shutdown</span>
+        ) : isOngoingShutdown ? (
           <span>
-            * showing {14} days before shutdown and data collected during the ongoing shutdown
+            * showing 14 days before shutdown and data collected during the ongoing shutdown
           </span>
         ) : (
-          <span>* data shows {14} days before and after completed shutdown</span>
+          <span>* data shows 14 days before and after completed shutdown</span>
         )}
       </div>
     </div>

--- a/src/components/Shutdowns/ShutdownDetails.tsx
+++ b/src/components/Shutdowns/ShutdownDetails.tsx
@@ -35,6 +35,8 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
     setIsReversed((prev) => !prev);
   };
 
+  const isFutureShutdown = dayjs().isBefore(dayjs(shutdown.start_date));
+
   // Shutdown title card component
   const ShutdownTitleCard = () => {
     const formatDate = (date: string) => dayjs(date).format('MM/DD/YY');
@@ -86,14 +88,14 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
 
   const afterShutdownQueryOptions = {
     ...queryOptions,
-    end_date: dayjs(shutdown.stop_date).add(8, 'day').format('YYYY-MM-DD'),
+    end_date: dayjs(shutdown.stop_date).add(14, 'day').format('YYYY-MM-DD'),
     start_date: dayjs(shutdown.stop_date).add(1, 'day').format('YYYY-MM-DD'),
   };
 
   const beforeShutdownQueryOptions = {
     ...queryOptions,
     end_date: dayjs(shutdown.start_date).subtract(1, 'day').format('YYYY-MM-DD'),
-    start_date: dayjs(shutdown.start_date).subtract(8, 'day').format('YYYY-MM-DD'),
+    start_date: dayjs(shutdown.start_date).subtract(14, 'day').format('YYYY-MM-DD'),
   };
 
   const beforeData = useTripExplorerQueries(beforeShutdownQueryOptions, true);
@@ -150,7 +152,16 @@ const ShutdownDetails: React.FunctionComponent<ShutdownDetailsProps> = ({
         <ShutdownMap shutdown={shutdown} line={line} />
       </div>
       <div className="dark:text-white text-gray-500 text-sm">
-        * data shows 7 days before and after shutdown
+        {isFutureShutdown ? (
+          <span>* showing {14} days of historical data before the scheduled shutdown</span>
+        ) : dayjs().isAfter(dayjs(shutdown.start_date)) &&
+          dayjs().isBefore(dayjs(shutdown.stop_date)) ? (
+          <span>
+            * showing {14} days before shutdown and data collected during the ongoing shutdown
+          </span>
+        ) : (
+          <span>* data shows {14} days before and after completed shutdown</span>
+        )}
       </div>
     </div>
   );

--- a/src/components/charts/AggregateLineChart.tsx
+++ b/src/components/charts/AggregateLineChart.tsx
@@ -17,10 +17,12 @@ import { useStore } from '../../store';
 import { filterPeakData } from '../../utils/travelTimes';
 import { AggregateLineProps } from './types';
 
-const xAxisLabel = (startDate: string, endDate: string) => {
-  const y1 = startDate.split('-')[0];
-  const y2 = endDate.split('-')[0];
-  return y1 === y2 ? y1 : `${y1} – ${y2}`;
+const generateDayLabels = (daysCount: number): string[] => {
+  const labels: string[] = [];
+  for (let i = 1; i <= daysCount; i++) {
+    labels.push(`Day ${i}`);
+  }
+  return labels;
 };
 
 export const AggregateLineChart: React.FC<AggregateLineProps> = ({
@@ -28,9 +30,6 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
   before,
   after,
   line,
-  pointField,
-  timeUnit,
-  timeFormat,
   startDate,
   endDate,
   suggestedYMin,
@@ -43,9 +42,18 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
   const afterData = after.isSuccess ? filterPeakData(after.data.by_date!) : [];
   const beforeData = before.isSuccess ? filterPeakData(before.data.by_date!) : [];
 
+  const isOlderThanTwoWeeks = dayjs().diff(dayjs(shutdown.stop_date), 'day') > 14;
+  const isFutureShutdown = dayjs().isBefore(dayjs(shutdown.start_date));
+  const isOngoingShutdown =
+    dayjs().isAfter(dayjs(shutdown.start_date)) && dayjs().isBefore(dayjs(shutdown.stop_date));
+  const isFinishedShutdown = dayjs().isAfter(dayjs(shutdown.stop_date));
+
   const ref = useRef();
   const isMobile = !useBreakpoint('md');
-  const labels = beforeData.map((item) => item[pointField]);
+
+  const dayLabels = generateDayLabels(14);
+
+  const watermarkOptions = watermarkLayout(isMobile, darkMode);
 
   return (
     <Line
@@ -53,7 +61,7 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
       ref={ref}
       redraw={true}
       data={{
-        labels,
+        labels: dayLabels,
         datasets: [
           {
             label: 'Before shutdown',
@@ -102,28 +110,13 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
           },
           x: {
             ticks: {
-              display: false,
+              color: darkMode ? 'white' : 'black',
             },
-
-            time: {
-              unit: timeUnit,
-              // @ts-expect-error The typing expectations are wrong
-              stepSize: 1,
-              tooltipFormat: timeFormat,
-            },
-            type: 'time',
-            adapters: {
-              date: {
-                locale: enUS,
-              },
-            },
-            // force graph to show startDate to endDate, even if missing data
-            min: startDate,
-            max: endDate,
+            type: 'category',
             title: {
               color: darkMode ? 'white' : 'black',
               display: true,
-              text: xAxisLabel(startDate ?? '', endDate ?? ''),
+              text: 'Day of data collection',
             },
           },
         },
@@ -134,7 +127,8 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
           mode: 'index',
           intersect: false,
         },
-        watermark: watermarkLayout(isMobile, darkMode),
+        // @ts-ignore - Using plugin that requires watermark property
+        watermark: watermarkOptions,
         plugins: {
           legend: {
             display: true,
@@ -147,16 +141,11 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
             position: 'nearest',
             callbacks: {
               title: (tooltipItems) => {
-                const beforePointDate = dayjs(shutdown.start_date).subtract(
-                  8 - tooltipItems[0].dataIndex,
-                  'day'
-                );
-                const afterPointDate = dayjs(shutdown.stop_date).add(
-                  tooltipItems[0].dataIndex + 1,
-                  'day'
-                );
+                const index = tooltipItems[0].dataIndex;
+                const beforePointDate = dayjs(shutdown.start_date).subtract(14 - index, 'day');
+                const afterPointDate = dayjs(shutdown.stop_date).add(index + 1, 'day');
 
-                return `${`${beforePointDate.format('MMM D, YYYY')} - ${afterPointDate.format('MMM D, YYYY')}`}`;
+                return `Day ${index + 1}\nBefore: ${beforePointDate.format('MMM D, YYYY')}\nAfter: ${afterPointDate.format('MMM D, YYYY')}`;
               },
               label: (tooltipItem) => {
                 return `${tooltipItem.dataset.label}: ${getFormattedTimeString(
@@ -180,8 +169,22 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
               beforeData.length === 0
             ) {
               writeError(chart);
-            } else if (afterData.length < 7) {
-              writeError(chart, 'Analysis still in progress, numbers not final.');
+            } else if (afterData.length < 14) {
+              // Only show "in progress" message if we're less than a week after shutdown ended
+              // or if it's a future shutdown
+              const daysSinceShutdownEnded = dayjs().diff(dayjs(shutdown.stop_date), 'day');
+              if (daysSinceShutdownEnded < 7) {
+                writeError(chart, 'Analysis still in progress, numbers not final.');
+              } else if (isFutureShutdown) {
+                writeError(
+                  chart,
+                  '🔜 Showing historical data only - shutdown has not started yet.'
+                );
+              } else if (isOngoingShutdown) {
+                writeError(chart, '🚧 Shutdown in progress - data collection ongoing.');
+              } else if (isFinishedShutdown && !isOlderThanTwoWeeks) {
+                writeError(chart, '✅ Shutdown complete - recent data may still be processing.');
+              }
             }
           },
         },

--- a/src/components/charts/AggregateLineChart.tsx
+++ b/src/components/charts/AggregateLineChart.tsx
@@ -2,7 +2,6 @@ import { Line } from 'react-chartjs-2';
 import type { Chart as ChartJS } from 'chart.js';
 
 import 'chartjs-adapter-date-fns';
-import { enUS } from 'date-fns/locale';
 import React, { useRef } from 'react';
 import ChartjsPluginWatermark from 'chartjs-plugin-watermark';
 import dayjs from 'dayjs';
@@ -163,17 +162,13 @@ export const AggregateLineChart: React.FC<AggregateLineProps> = ({
           afterDraw: (chart: ChartJS) => {
             if (before.isPending || after.isPending) {
               writeError(chart, 'Loading...');
-            } else if (
-              startDate === undefined ||
-              endDate === undefined ||
-              beforeData.length === 0
-            ) {
+            } else if (startDate === undefined || endDate === undefined) {
               writeError(chart);
             } else if (afterData.length < 14) {
               // Only show "in progress" message if we're less than a week after shutdown ended
               // or if it's a future shutdown
               const daysSinceShutdownEnded = dayjs().diff(dayjs(shutdown.stop_date), 'day');
-              if (daysSinceShutdownEnded < 7) {
+              if (daysSinceShutdownEnded < 14 && !isFutureShutdown) {
                 writeError(chart, 'Analysis still in progress, numbers not final.');
               } else if (isFutureShutdown) {
                 writeError(

--- a/src/components/charts/TravelTimesChart.tsx
+++ b/src/components/charts/TravelTimesChart.tsx
@@ -15,7 +15,7 @@ interface TravelTimesChartProps {
 }
 
 const TravelTimesChart = ({ shutdown, before, after, line }: TravelTimesChartProps) => {
-  const start_date = dayjs(shutdown.start_date).subtract(8, 'day').format('YYYY-MM-DD');
+  const start_date = dayjs(shutdown.start_date).subtract(14, 'day').format('YYYY-MM-DD');
   const end_date = dayjs(shutdown.start_date).subtract(1, 'day').format('YYYY-MM-DD');
 
   return (

--- a/src/components/maps/diagrams/diagram.ts
+++ b/src/components/maps/diagrams/diagram.ts
@@ -27,11 +27,17 @@ const getStationDisplacementMap = (
     for (const range of path.getRanges()) {
       const stations = stationsByRangeName[range];
       if (stations) {
-        for (let i = 0; i < stations.length; i++) {
-          const station = stations[i];
-          const fraction = i / (stations.length - 1);
-          const displacement = path.getDisplacementFromRangeLookup({ fraction, range });
-          pathIndex[station.station] = displacement;
+        // For single station, place it at the start of the path
+        if (stations.length === 1) {
+          const station = stations[0];
+          pathIndex[station.station] = 0;
+        } else {
+          for (let i = 0; i < stations.length; i++) {
+            const station = stations[i];
+            const fraction = i / (stations.length - 1);
+            const displacement = path.getDisplacementFromRangeLookup({ fraction, range });
+            pathIndex[station.station] = displacement;
+          }
         }
       }
     }

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -187,7 +187,7 @@
     },
     {
       "start_station": "Boston College",
-      "end_station": "Boston College",
+      "end_station": "South Street",
       "start_date": "2025-04-11",
       "stop_date": "2025-04-13"
     },
@@ -211,7 +211,7 @@
     },
     {
       "start_station": "Boston College",
-      "end_station": "Boston College",
+      "end_station": "South Street",
       "start_date": "2025-05-02",
       "stop_date": "2025-05-04"
     },


### PR DESCRIPTION
## Motivation
- Been wanting to make some misc UI updates
- Shows 14 days of data instead of 7.
- Shows new messaging for completed, in progress, and future shutdowns.
- For future shutdowns, shows the last 14 days of data.
<img width="1728" alt="Screenshot 2025-05-01 at 7 48 49 PM" src="https://github.com/user-attachments/assets/a25fa806-d003-489a-b1e7-ff67092cb26b" />
<img width="1728" alt="Screenshot 2025-05-01 at 7 48 28 PM" src="https://github.com/user-attachments/assets/0ed17ab3-f30d-43f8-919d-d7b1d1a99032" />
<img width="1728" alt="Screenshot 2025-05-01 at 7 51 30 PM" src="https://github.com/user-attachments/assets/09fa5b0a-cca3-47a5-bef5-71fb09ca32df" />


<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
