### PR TITLE
Add April 2026 Green Line shutdowns

### DIFF
--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -346,6 +346,34 @@
       "start_date": "2025-12-08",
       "stop_date": "2025-12-22",
       "alert": "https://www.mbta.com/projects/2025-planned-closures"
+    },
+    {
+      "start_station": "Boston College",
+      "end_station": "Kenmore",
+      "start_date": "2026-04-22",
+      "stop_date": "2026-04-30",
+      "alert": "https://www.mbta.com/alerts/subway"
+    },
+    {
+      "start_station": "Kenmore",
+      "end_station": "Government Center",
+      "start_date": "2026-04-25",
+      "stop_date": "2026-04-26",
+      "alert": "https://www.mbta.com/alerts/subway"
+    },
+    {
+      "start_station": "Saint Marys Street",
+      "end_station": "Government Center",
+      "start_date": "2026-04-25",
+      "stop_date": "2026-04-26",
+      "alert": "https://www.mbta.com/alerts/subway"
+    },
+    {
+      "start_station": "Brookline Hills",
+      "end_station": "Union Square",
+      "start_date": "2026-04-25",
+      "stop_date": "2026-04-26",
+      "alert": "https://www.mbta.com/alerts/subway"
     }
   ],
   "red": [

--- a/src/constants/shutdowns.json
+++ b/src/constants/shutdowns.json
@@ -355,6 +355,13 @@
       "alert": "https://www.mbta.com/alerts/subway"
     },
     {
+      "start_station": "Brookline Hills",
+      "end_station": "Union Square",
+      "start_date": "2026-04-25",
+      "stop_date": "2026-04-26",
+      "alert": "https://www.mbta.com/alerts/subway"
+    },
+    {
       "start_station": "Kenmore",
       "end_station": "Government Center",
       "start_date": "2026-04-25",
@@ -364,13 +371,6 @@
     {
       "start_station": "Saint Marys Street",
       "end_station": "Government Center",
-      "start_date": "2026-04-25",
-      "stop_date": "2026-04-26",
-      "alert": "https://www.mbta.com/alerts/subway"
-    },
-    {
-      "start_station": "Brookline Hills",
-      "end_station": "Union Square",
       "start_date": "2026-04-25",
       "stop_date": "2026-04-26",
       "alert": "https://www.mbta.com/alerts/subway"


### PR DESCRIPTION
## Summary
- GL-B: Boston College → Kenmore shutdown 4/22–4/30
- GL-B weekend extension: Kenmore → Government Center 4/25–4/26
- GL-C: Saint Marys Street → Government Center 4/25–4/26
- GL-D: Brookline Hills → Union Square 4/25–4/26

## Test plan
- [ ] Verify shutdowns render correctly on the tracker
- [ ] Verify calendar export includes the new entries